### PR TITLE
feat: warm pool pods in SandboxPool.create

### DIFF
--- a/src/common/time.ts
+++ b/src/common/time.ts
@@ -1,0 +1,8 @@
+/**
+ * Sleep for `ms` milliseconds. Resolves on the next event-loop tick after
+ * the timer fires. Used by both polling loops in `sandbox.ts` and `pool.ts`
+ * to keep their cadence consistent and avoid duplicating the helper.
+ */
+export function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/sandbox/pool.ts
+++ b/src/sandbox/pool.ts
@@ -1,6 +1,7 @@
 import { Config, type ConfigOptions } from "../common/config.js";
 import type { EnvVar, PoolInfo, ResourceRequests } from "./models.js";
 import { PoolClient } from "./pool-client.js";
+import { Sandbox } from "./sandbox.js";
 
 /**
  * Options for {@link SandboxPool.create}. New fields are optional; omitted
@@ -21,6 +22,21 @@ export interface CreatePoolOptions extends ConfigOptions {
 	envVars?: EnvVar[];
 	/** Names of Kubernetes secrets to mount/reference in each pool member. */
 	secretRefs?: string[];
+	/**
+	 * If true (default), `SandboxPool.create` blocks until the pool's pods
+	 * reach `readyReplicas >= poolSize` and then claims a single sandbox to
+	 * run the Jupyter kernel warmup probe against. This guarantees the
+	 * first subsequent `Sandbox.fromPool` claim is not racing the
+	 * ipykernel cold-start window (~1.7s after pod Running). Set to
+	 * `false` to preserve the legacy instant-return behaviour.
+	 */
+	waitUntilReady?: boolean;
+	/**
+	 * Maximum number of seconds to wait for pool pods to become ready and
+	 * for the warmup probe to complete. Only used when `waitUntilReady`
+	 * is not false. Defaults to 300 seconds.
+	 */
+	readyTimeout?: number;
 }
 
 export class SandboxPool {
@@ -48,10 +64,28 @@ export class SandboxPool {
 
 	/**
 	 * Create a new warm pool.
+	 *
+	 * By default (`waitUntilReady` unset or true), this blocks until the
+	 * pool's pods reach `readyReplicas >= poolSize`, then claims one
+	 * sandbox and runs the Jupyter kernel warmup probe against it via
+	 * `Sandbox.waitUntilReady()`, then kills the probe sandbox. The
+	 * probe's wall-clock is roughly the ipykernel cold-start window, so
+	 * by the time this call returns the other pool pods have had similar
+	 * warm-up time. This eliminates the cold-kernel race on the first
+	 * `Sandbox.fromPool` + `runCode` sequence against a fresh pool.
+	 *
+	 * Pass `waitUntilReady: false` to preserve the legacy behaviour of
+	 * returning immediately after the CR is created.
+	 *
+	 * Warmup is best-effort: a timeout or probe error after the pool CR
+	 * has been created is logged via `console.warn` and the pool is still
+	 * returned. Errors from the underlying pool create API call itself
+	 * always propagate.
 	 */
 	static async create(options: CreatePoolOptions): Promise<SandboxPool> {
 		const config = new Config(options);
 		const client = new PoolClient(config);
+		let pool: SandboxPool;
 		try {
 			const info = await client.create({
 				name: options.name,
@@ -63,10 +97,85 @@ export class SandboxPool {
 				envVars: options.envVars,
 				secretRefs: options.secretRefs,
 			});
-			return new SandboxPool(info, client);
+			pool = new SandboxPool(info, client);
 		} catch (e) {
 			client.close();
 			throw e;
+		}
+
+		if (options.waitUntilReady === false) {
+			return pool;
+		}
+
+		const readyTimeoutSec = options.readyTimeout ?? 300;
+		try {
+			await SandboxPool.warmPoolPods(pool, options, readyTimeoutSec);
+		} catch (e) {
+			// Best-effort warmup: never block pool handoff on probe errors.
+			// Real pool-creation errors already propagated above.
+			console.warn(
+				`SandboxPool '${options.name}': warmup failed (${
+					e instanceof Error ? e.message : String(e)
+				}); returning pool anyway`,
+			);
+		}
+		return pool;
+	}
+
+	/**
+	 * Internal: wait for pool readiness then run a single cold-kernel
+	 * warmup probe via a claimed sandbox. Bounded by `timeoutSec`. May
+	 * throw — the caller (`create`) swallows and logs per "best-effort"
+	 * contract.
+	 */
+	private static async warmPoolPods(
+		pool: SandboxPool,
+		options: CreatePoolOptions,
+		timeoutSec: number,
+	): Promise<void> {
+		const deadline = Date.now() + timeoutSec * 1000;
+		const pollIntervalMs = 2000;
+
+		// Phase 1: poll refresh() until readyReplicas >= poolSize or deadline.
+		while (pool.readyReplicas < options.poolSize) {
+			const remainingMs = deadline - Date.now();
+			if (remainingMs <= 0) {
+				console.warn(
+					`SandboxPool '${options.name}': timed out waiting for ${options.poolSize} ready replicas (saw ${pool.readyReplicas}); skipping warmup probe`,
+				);
+				return;
+			}
+			await sleep(Math.min(pollIntervalMs, remainingMs));
+			await pool.refresh();
+		}
+
+		// Phase 2: claim one sandbox, run the warmup probe via the
+		// existing Sandbox.waitUntilReady() path (which internally runs
+		// warmupKernel), then kill it. The remaining budget is what's
+		// left of readyTimeout after waiting for pods to come up.
+		const remainingMs = deadline - Date.now();
+		if (remainingMs <= 0) {
+			console.warn(`SandboxPool '${options.name}': no time budget left for warmup probe; skipping`);
+			return;
+		}
+		const probeTimeoutSec = Math.max(1, Math.floor(remainingMs / 1000));
+
+		const sbx = await Sandbox.fromPool(options.name, options);
+		try {
+			await sbx.waitUntilReady(probeTimeoutSec);
+		} finally {
+			try {
+				await sbx.kill();
+			} catch (e) {
+				// Swallow kill errors — if the probe already succeeded we
+				// don't want to fail the outer create, and if it didn't the
+				// outer catch in create() will log anyway.
+				console.warn(
+					`SandboxPool '${options.name}': failed to kill warmup probe sandbox '${sbx.name}' (${
+						e instanceof Error ? e.message : String(e)
+					})`,
+				);
+			}
 		}
 	}
 
@@ -153,4 +262,8 @@ export class SandboxPool {
 		if (info.cpu) this._cpu = info.cpu;
 		if (info.memory) this._memory = info.memory;
 	}
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/sandbox/pool.ts
+++ b/src/sandbox/pool.ts
@@ -1,4 +1,5 @@
 import { Config, type ConfigOptions } from "../common/config.js";
+import { sleep } from "../common/time.js";
 import type { EnvVar, PoolInfo, ResourceRequests } from "./models.js";
 import { PoolClient } from "./pool-client.js";
 import { Sandbox } from "./sandbox.js";
@@ -24,11 +25,17 @@ export interface CreatePoolOptions extends ConfigOptions {
 	secretRefs?: string[];
 	/**
 	 * If true (default), `SandboxPool.create` blocks until the pool's pods
-	 * reach `readyReplicas >= poolSize` and then claims a single sandbox to
-	 * run the Jupyter kernel warmup probe against. This guarantees the
-	 * first subsequent `Sandbox.fromPool` claim is not racing the
-	 * ipykernel cold-start window (~1.7s after pod Running). Set to
-	 * `false` to preserve the legacy instant-return behaviour.
+	 * reach `readyReplicas >= poolSize` and then claims a single sandbox
+	 * to run the Jupyter kernel warmup probe against, in order to
+	 * mitigate the cold-kernel race on the first subsequent
+	 * `Sandbox.fromPool` claim (the ipykernel cold-start window is
+	 * ~1.7s after pod Running). Set to `false` to preserve the legacy
+	 * instant-return behaviour.
+	 *
+	 * The warmup is best-effort: a readiness or probe timeout after the
+	 * pool CR has been created is logged via `console.warn` and the pool
+	 * is still returned. Errors from the underlying pool create API call
+	 * itself always propagate.
 	 */
 	waitUntilReady?: boolean;
 	/**
@@ -71,13 +78,16 @@ export class SandboxPool {
 	 * `Sandbox.waitUntilReady()`, then kills the probe sandbox. The
 	 * probe's wall-clock is roughly the ipykernel cold-start window, so
 	 * by the time this call returns the other pool pods have had similar
-	 * warm-up time. This eliminates the cold-kernel race on the first
-	 * `Sandbox.fromPool` + `runCode` sequence against a fresh pool.
+	 * warm-up time. This *mitigates* the cold-kernel race on the first
+	 * `Sandbox.fromPool` + `runCode` sequence against a fresh pool, but
+	 * cannot guarantee it: readiness can time out, and
+	 * `Sandbox.waitUntilReady` itself logs a warning and returns when its
+	 * own probe deadline expires without seeing the marker.
 	 *
 	 * Pass `waitUntilReady: false` to preserve the legacy behaviour of
 	 * returning immediately after the CR is created.
 	 *
-	 * Warmup is best-effort: a timeout or probe error after the pool CR
+	 * Warmup is best-effort: a readiness or probe error after the pool CR
 	 * has been created is logged via `console.warn` and the pool is still
 	 * returned. Errors from the underlying pool create API call itself
 	 * always propagate.
@@ -136,29 +146,45 @@ export class SandboxPool {
 		const deadline = Date.now() + timeoutSec * 1000;
 		const pollIntervalMs = 2000;
 
-		// Phase 1: poll refresh() until readyReplicas >= poolSize or deadline.
-		while (pool.readyReplicas < options.poolSize) {
+		// Phase 1: poll refresh() until readyReplicas >= the backend-reported
+		// desired count or deadline. Refresh BEFORE the first sleep so an
+		// already-ready pool returns immediately without burning ~2s of
+		// poll-interval (and ~2s of the readyTimeout budget). Compare against
+		// pool.replicas (the backend's desired count) rather than
+		// options.poolSize, since the backend may clamp or apply defaults.
+		while (true) {
+			await pool.refresh();
+			if (pool.readyReplicas >= pool.replicas) break;
+
 			const remainingMs = deadline - Date.now();
 			if (remainingMs <= 0) {
 				console.warn(
-					`SandboxPool '${options.name}': timed out waiting for ${options.poolSize} ready replicas (saw ${pool.readyReplicas}); skipping warmup probe`,
+					`SandboxPool '${options.name}': timed out waiting for ${pool.replicas} ready replicas (saw ${pool.readyReplicas}); skipping warmup probe`,
 				);
 				return;
 			}
 			await sleep(Math.min(pollIntervalMs, remainingMs));
-			await pool.refresh();
 		}
 
 		// Phase 2: claim one sandbox, run the warmup probe via the
 		// existing Sandbox.waitUntilReady() path (which internally runs
 		// warmupKernel), then kill it. The remaining budget is what's
 		// left of readyTimeout after waiting for pods to come up.
+		//
+		// Sandbox.waitUntilReady's deadline math is millisecond-precise but
+		// its parameter is an integer second count internally clamped by
+		// warmupKernel (which itself skips when <1s remains). To avoid
+		// overrunning the caller's readyTimeout budget by up to ~999ms, we
+		// only run the probe when at least 1s of budget remains, and pass
+		// the floor of the remaining seconds rather than rounding up.
 		const remainingMs = deadline - Date.now();
-		if (remainingMs <= 0) {
-			console.warn(`SandboxPool '${options.name}': no time budget left for warmup probe; skipping`);
+		if (remainingMs < 1000) {
+			console.warn(
+				`SandboxPool '${options.name}': less than 1s of warmup budget remains after readiness poll; skipping warmup probe`,
+			);
 			return;
 		}
-		const probeTimeoutSec = Math.max(1, Math.floor(remainingMs / 1000));
+		const probeTimeoutSec = Math.floor(remainingMs / 1000);
 
 		const sbx = await Sandbox.fromPool(options.name, options);
 		try {
@@ -169,12 +195,20 @@ export class SandboxPool {
 			} catch (e) {
 				// Swallow kill errors — if the probe already succeeded we
 				// don't want to fail the outer create, and if it didn't the
-				// outer catch in create() will log anyway.
+				// outer catch in create() will log anyway. Note that
+				// Sandbox.kill only closes the underlying HTTP client after
+				// a successful delete; on failure the client stays open and
+				// would leak in long-lived processes. Close it explicitly.
 				console.warn(
 					`SandboxPool '${options.name}': failed to kill warmup probe sandbox '${sbx.name}' (${
 						e instanceof Error ? e.message : String(e)
-					})`,
+					}); closing its client to avoid a connection leak`,
 				);
+				try {
+					(sbx as unknown as { _client: { close(): void } })._client.close();
+				} catch {
+					// Last-ditch best-effort; nothing else we can do here.
+				}
 			}
 		}
 	}
@@ -262,8 +296,4 @@ export class SandboxPool {
 		if (info.cpu) this._cpu = info.cpu;
 		if (info.memory) this._memory = info.memory;
 	}
-}
-
-function sleep(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/sandbox/pool.ts
+++ b/src/sandbox/pool.ts
@@ -25,7 +25,9 @@ export interface CreatePoolOptions extends ConfigOptions {
 	secretRefs?: string[];
 	/**
 	 * If true (default), `SandboxPool.create` blocks until the pool's pods
-	 * reach `readyReplicas >= poolSize` and then claims a single sandbox
+	 * reach `readyReplicas >= pool.replicas` (the backend-reported desired
+	 * replica count, which may differ from the requested `poolSize` if the
+	 * backend clamps or applies defaults) and then claims a single sandbox
 	 * to run the Jupyter kernel warmup probe against, in order to
 	 * mitigate the cold-kernel race on the first subsequent
 	 * `Sandbox.fromPool` claim (the ipykernel cold-start window is
@@ -73,8 +75,9 @@ export class SandboxPool {
 	 * Create a new warm pool.
 	 *
 	 * By default (`waitUntilReady` unset or true), this blocks until the
-	 * pool's pods reach `readyReplicas >= poolSize`, then claims one
-	 * sandbox and runs the Jupyter kernel warmup probe against it via
+	 * pool's pods reach `readyReplicas >= pool.replicas` (the
+	 * backend-reported desired count), then claims one sandbox and runs
+	 * the Jupyter kernel warmup probe against it via
 	 * `Sandbox.waitUntilReady()`, then kills the probe sandbox. The
 	 * probe's wall-clock is roughly the ipykernel cold-start window, so
 	 * by the time this call returns the other pool pods have had similar
@@ -195,20 +198,15 @@ export class SandboxPool {
 			} catch (e) {
 				// Swallow kill errors — if the probe already succeeded we
 				// don't want to fail the outer create, and if it didn't the
-				// outer catch in create() will log anyway. Note that
-				// Sandbox.kill only closes the underlying HTTP client after
-				// a successful delete; on failure the client stays open and
-				// would leak in long-lived processes. Close it explicitly.
+				// outer catch in create() will log anyway. Sandbox.kill now
+				// closes its underlying HTTP client in a finally block even
+				// when delete fails (see Sandbox.kill), so there's no
+				// connection leak to clean up here.
 				console.warn(
 					`SandboxPool '${options.name}': failed to kill warmup probe sandbox '${sbx.name}' (${
 						e instanceof Error ? e.message : String(e)
-					}); closing its client to avoid a connection leak`,
+					})`,
 				);
-				try {
-					(sbx as unknown as { _client: { close(): void } })._client.close();
-				} catch {
-					// Last-ditch best-effort; nothing else we can do here.
-				}
 			}
 		}
 	}

--- a/src/sandbox/pool.ts
+++ b/src/sandbox/pool.ts
@@ -155,6 +155,12 @@ export class SandboxPool {
 		// poll-interval (and ~2s of the readyTimeout budget). Compare against
 		// pool.replicas (the backend's desired count) rather than
 		// options.poolSize, since the backend may clamp or apply defaults.
+		// Use the backend-reported pool name from here on. The backend may
+		// normalise the requested name (e.g. lowercase, truncate, suffix),
+		// in which case `options.name` and `pool.name` could differ — claim
+		// against `pool.name` so the probe definitely targets this pool.
+		const poolName = pool.name;
+
 		while (true) {
 			await pool.refresh();
 			if (pool.readyReplicas >= pool.replicas) break;
@@ -162,7 +168,7 @@ export class SandboxPool {
 			const remainingMs = deadline - Date.now();
 			if (remainingMs <= 0) {
 				console.warn(
-					`SandboxPool '${options.name}': timed out waiting for ${pool.replicas} ready replicas (saw ${pool.readyReplicas}); skipping warmup probe`,
+					`SandboxPool '${poolName}': timed out waiting for ${pool.replicas} ready replicas (saw ${pool.readyReplicas}); skipping warmup probe`,
 				);
 				return;
 			}
@@ -183,27 +189,26 @@ export class SandboxPool {
 		const remainingMs = deadline - Date.now();
 		if (remainingMs < 1000) {
 			console.warn(
-				`SandboxPool '${options.name}': less than 1s of warmup budget remains after readiness poll; skipping warmup probe`,
+				`SandboxPool '${poolName}': less than 1s of warmup budget remains after readiness poll; skipping warmup probe`,
 			);
 			return;
 		}
 		const probeTimeoutSec = Math.floor(remainingMs / 1000);
 
-		const sbx = await Sandbox.fromPool(options.name, options);
+		const sbx = await Sandbox.fromPool(poolName, options);
 		try {
 			await sbx.waitUntilReady(probeTimeoutSec);
 		} finally {
 			try {
 				await sbx.kill();
 			} catch (e) {
-				// Swallow kill errors — if the probe already succeeded we
-				// don't want to fail the outer create, and if it didn't the
-				// outer catch in create() will log anyway. Sandbox.kill now
-				// closes its underlying HTTP client in a finally block even
-				// when delete fails (see Sandbox.kill), so there's no
-				// connection leak to clean up here.
+				// Swallow kill errors. The probe sandbox is short-lived and
+				// the outer create() will log via its own catch as well.
+				// Sandbox.kill() now closes the underlying HttpClient in a
+				// finally block too, so there's nothing extra to clean up
+				// here even on failure.
 				console.warn(
-					`SandboxPool '${options.name}': failed to kill warmup probe sandbox '${sbx.name}' (${
+					`SandboxPool '${poolName}': failed to kill warmup probe sandbox '${sbx.name}' (${
 						e instanceof Error ? e.message : String(e)
 					})`,
 				);

--- a/src/sandbox/pool.ts
+++ b/src/sandbox/pool.ts
@@ -120,7 +120,18 @@ export class SandboxPool {
 			return pool;
 		}
 
-		const readyTimeoutSec = options.readyTimeout ?? 300;
+		// Validate readyTimeout: a NaN or negative value would make
+		// `Date.now() + timeoutSec * 1000` produce NaN/-∞ and turn the
+		// readiness loop into an unbounded poll. Fall back to the default
+		// in that case rather than hanging silently.
+		const rawTimeout = options.readyTimeout ?? 300;
+		const readyTimeoutSec = Number.isFinite(rawTimeout) && rawTimeout >= 0 ? rawTimeout : 300;
+		if (readyTimeoutSec !== rawTimeout) {
+			console.warn(
+				`SandboxPool '${pool.name}': invalid readyTimeout ${String(rawTimeout)} ` +
+					`(must be a finite number >= 0); falling back to ${readyTimeoutSec}s`,
+			);
+		}
 		try {
 			await SandboxPool.warmPoolPods(pool, options, readyTimeoutSec);
 		} catch (e) {

--- a/src/sandbox/pool.ts
+++ b/src/sandbox/pool.ts
@@ -126,8 +126,10 @@ export class SandboxPool {
 		} catch (e) {
 			// Best-effort warmup: never block pool handoff on probe errors.
 			// Real pool-creation errors already propagated above.
+			// Use the backend-reported pool.name (not options.name) so the
+			// log points at the actual pool the backend created.
 			console.warn(
-				`SandboxPool '${options.name}': warmup failed (${
+				`SandboxPool '${pool.name}': warmup failed (${
 					e instanceof Error ? e.message : String(e)
 				}); returning pool anyway`,
 			);

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -312,10 +312,19 @@ export class Sandbox {
 
 	async kill(): Promise<void> {
 		if (this._killed) return;
-		await this._client.delete(this._name);
-		this._status = SandboxStatus.Succeeded;
-		this._killed = true;
-		this._client.close();
+		try {
+			await this._client.delete(this._name);
+			this._status = SandboxStatus.Succeeded;
+			this._killed = true;
+		} finally {
+			// Always close the underlying HTTP client, even when delete
+			// fails. Otherwise a network error during kill would leak the
+			// connection in long-lived processes (e.g. SandboxPool's
+			// best-effort warmup probe). The status/killed state is only
+			// updated on a successful delete so callers can still retry
+			// kill() to surface the error.
+			this._client.close();
+		}
 	}
 
 	async refresh(): Promise<void> {

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -317,12 +317,14 @@ export class Sandbox {
 			this._status = SandboxStatus.Succeeded;
 			this._killed = true;
 		} finally {
-			// Always close the underlying HTTP client, even when delete
-			// fails. Otherwise a network error during kill would leak the
-			// connection in long-lived processes (e.g. SandboxPool's
-			// best-effort warmup probe). The status/killed state is only
-			// updated on a successful delete so callers can still retry
-			// kill() to surface the error.
+			// Always close the underlying HTTP client in a finally block,
+			// even when delete fails. HttpClient.close() is currently a
+			// no-op for the native-fetch transport, but the API surface is
+			// kept symmetrical with the Python SDK and may grow real cleanup
+			// later (e.g. AbortController for in-flight requests). Calling
+			// it on every kill() path keeps the contract honest. The
+			// status/killed state is only updated on a successful delete so
+			// callers can still retry kill() to surface the error.
 			this._client.close();
 		}
 	}

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { Config, type ConfigOptions } from "../common/config.js";
 import { SandboxError, SandboxTimeoutError } from "../common/errors.js";
+import { sleep } from "../common/time.js";
 import { SandboxClient } from "./client.js";
 import { CodeRunner } from "./code.js";
 import { CommandRunner } from "./commands.js";
@@ -354,8 +355,4 @@ function randomHex(length: number): string {
 	return Array.from(bytes, (b) => b.toString(16).padStart(2, "0"))
 		.join("")
 		.slice(0, length);
-}
-
-function sleep(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/tests/pool.test.ts
+++ b/tests/pool.test.ts
@@ -316,9 +316,7 @@ describe("SandboxPool", () => {
 				const claimCalls = mockFetch.mock.calls.filter((c) =>
 					(c[0] as string).includes("/sandboxes/claim"),
 				);
-				const execCalls = mockFetch.mock.calls.filter((c) =>
-					(c[0] as string).includes("/exec"),
-				);
+				const execCalls = mockFetch.mock.calls.filter((c) => (c[0] as string).includes("/exec"));
 				expect(claimCalls.length).toBe(0);
 				expect(execCalls.length).toBe(0);
 			}, 10000);

--- a/tests/pool.test.ts
+++ b/tests/pool.test.ts
@@ -43,6 +43,10 @@ describe("SandboxPool", () => {
 				image: "python:3.10",
 				poolSize: 5,
 				resources: { cpu: "2", memory: "4Gi" },
+				// Opt out of the post-create warmup probe for this unit
+				// test; the probe path is covered by dedicated tests
+				// below.
+				waitUntilReady: false,
 			});
 
 			expect(pool.name).toBe("gpu-pool");
@@ -67,6 +71,7 @@ describe("SandboxPool", () => {
 				name: "gpu-pool",
 				image: "python:3.10",
 				poolSize: 5,
+				waitUntilReady: false,
 			});
 
 			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
@@ -88,6 +93,7 @@ describe("SandboxPool", () => {
 				allowInternetAccess: true,
 				envVars: [{ name: "FOO", value: "bar" }],
 				secretRefs: ["my-secret"],
+				waitUntilReady: false,
 			});
 
 			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
@@ -96,6 +102,151 @@ describe("SandboxPool", () => {
 			expect(body.secretRefs).toEqual(["my-secret"]);
 			expect(body.cpu).toBe("2");
 			expect(body.memory).toBe("4Gi");
+		});
+
+		describe("warmup", () => {
+			// Helper: respond to a probe /exec call by echoing back the marker.
+			// See tests/sandbox.test.ts for the same helper used against
+			// Sandbox.waitUntilReady directly.
+			function probeRespond(body: string): Response {
+				const parsed = JSON.parse(body);
+				const code = parsed.code as string;
+				const match = code.match(/print\("(__pk_warmup_[a-f0-9]+__)"\)/);
+				if (!match) {
+					throw new Error(`Unexpected probe request body: ${body}`);
+				}
+				return mockResponse({
+					stdout: `${match[1]}\n`,
+					stderr: "",
+					success: true,
+					durationMs: 5,
+					session_id: "sess-warm",
+				});
+			}
+
+			const readyPoolData = {
+				name: "warm-pool",
+				replicas: 1,
+				readyReplicas: 1,
+				image: "python:3.10",
+				cpu: "1",
+				memory: "1Gi",
+			};
+
+			it("warms pool pods when waitUntilReady is true (default)", async () => {
+				const mockFetch = vi.mocked(fetch);
+				// 1. POST create pool — already has ready replicas so no
+				//    refresh-poll iterations needed.
+				mockFetch.mockResolvedValueOnce(mockResponse(readyPoolData));
+				// 2. POST claim sandbox from pool.
+				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-warm", status: "Running" }));
+				// 3. GET sandbox (waitUntilReady -> refresh).
+				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-warm", status: "Running" }));
+				// 4. POST /exec — warmup probe echoing marker.
+				mockFetch.mockImplementationOnce(async (_url, init) =>
+					probeRespond((init as RequestInit).body as string),
+				);
+				// 5. DELETE sandbox (kill probe sbx).
+				mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+				const pool = await SandboxPool.create({
+					...defaultConfig,
+					name: "warm-pool",
+					image: "python:3.10",
+					poolSize: 1,
+					readyTimeout: 10,
+				});
+
+				expect(pool.name).toBe("warm-pool");
+
+				// Must have made exactly one /exec call (the warmup probe)
+				// before returning from create.
+				const execCalls = mockFetch.mock.calls.filter((c) => {
+					const url = c[0] as string;
+					return url.includes("/exec");
+				});
+				expect(execCalls.length).toBe(1);
+
+				// And must have claimed one sandbox from the pool.
+				const claimCalls = mockFetch.mock.calls.filter((c) => {
+					const url = c[0] as string;
+					return url.includes("/sandboxes/claim");
+				});
+				expect(claimCalls.length).toBe(1);
+			});
+
+			it("opts out of warmup when waitUntilReady=false", async () => {
+				const mockFetch = vi.mocked(fetch);
+				mockFetch.mockResolvedValueOnce(mockResponse(readyPoolData));
+
+				await SandboxPool.create({
+					...defaultConfig,
+					name: "warm-pool",
+					image: "python:3.10",
+					poolSize: 1,
+					waitUntilReady: false,
+				});
+
+				// No probe exec and no claim — just the one create call.
+				expect(mockFetch.mock.calls.length).toBe(1);
+				const execCalls = mockFetch.mock.calls.filter((c) => {
+					const url = c[0] as string;
+					return url.includes("/exec");
+				});
+				expect(execCalls.length).toBe(0);
+				const claimCalls = mockFetch.mock.calls.filter((c) => {
+					const url = c[0] as string;
+					return url.includes("/sandboxes/claim");
+				});
+				expect(claimCalls.length).toBe(0);
+			});
+
+			it("does not throw if warmup probe times out", async () => {
+				const mockFetch = vi.mocked(fetch);
+				// 1. POST create pool — already ready.
+				mockFetch.mockResolvedValueOnce(mockResponse(readyPoolData));
+				// 2. POST claim.
+				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-warm", status: "Running" }));
+				// 3+. Every subsequent call returns either a Running status
+				//     for GET refresh, or an empty-stdout result for /exec,
+				//     or a 204 for DELETE. The probe will never see the
+				//     marker and will time out, but the outer create must
+				//     still resolve.
+				mockFetch.mockImplementation(async (url, init) => {
+					const u = url as string;
+					const method = (init as RequestInit | undefined)?.method ?? "GET";
+					if (method === "DELETE") {
+						return new Response(null, { status: 204 });
+					}
+					if (u.includes("/exec")) {
+						return mockResponse({
+							stdout: "",
+							stderr: "",
+							success: true,
+							durationMs: 5,
+							session_id: "sess-warm",
+						});
+					}
+					return mockResponse({ name: "sb-warm", status: "Running" });
+				});
+
+				// Silence expected warnings from the unresolved probe and
+				// from the best-effort warmup wrapper.
+				const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+				try {
+					await expect(
+						SandboxPool.create({
+							...defaultConfig,
+							name: "warm-pool",
+							image: "python:3.10",
+							poolSize: 1,
+							readyTimeout: 2,
+						}),
+					).resolves.toBeDefined();
+				} finally {
+					warnSpy.mockRestore();
+				}
+			}, 10000);
 		});
 	});
 

--- a/tests/pool.test.ts
+++ b/tests/pool.test.ts
@@ -261,6 +261,67 @@ describe("SandboxPool", () => {
 					warnSpy.mockRestore();
 				}
 			}, 10000);
+
+			it("does not throw if pool readiness never reaches the desired count", async () => {
+				// Pool is created but readyReplicas stays below replicas for the
+				// entire readyTimeout window. warmPoolPods must:
+				//   - log a warning,
+				//   - return the pool anyway (best-effort),
+				//   - NOT attempt a claim or /exec probe (the probe phase is
+				//     gated on readiness succeeding).
+				const notReadyPoolData = {
+					name: "warm-pool",
+					replicas: 1,
+					readyReplicas: 0,
+					image: "python:3.10",
+					cpu: "1",
+					memory: "1Gi",
+				};
+
+				const mockFetch = vi.mocked(fetch);
+				// 1. POST create pool — desired=1, ready=0.
+				mockFetch.mockResolvedValueOnce(mockResponse(notReadyPoolData));
+				// 2+. Every refresh keeps the pool below desired so the
+				//     readiness loop eventually trips its readyTimeout.
+				//     Any other call (claim, /exec) would mean the probe
+				//     phase ran — which is what this test asserts must NOT
+				//     happen.
+				mockFetch.mockImplementation(async (url, init) => {
+					const u = url as string;
+					const method = (init as RequestInit | undefined)?.method ?? "GET";
+					if (u.includes("/sandbox-pools")) {
+						return mockResponse(notReadyPoolData);
+					}
+					throw new Error(
+						`unexpected ${method} ${u} — readiness never succeeded so no claim/probe should run`,
+					);
+				});
+
+				const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+				try {
+					await expect(
+						SandboxPool.create({
+							...defaultConfig,
+							name: "warm-pool",
+							image: "python:3.10",
+							poolSize: 1,
+							readyTimeout: 1,
+						}),
+					).resolves.toBeDefined();
+				} finally {
+					warnSpy.mockRestore();
+				}
+
+				// Must not have made a claim or /exec call.
+				const claimCalls = mockFetch.mock.calls.filter((c) =>
+					(c[0] as string).includes("/sandboxes/claim"),
+				);
+				const execCalls = mockFetch.mock.calls.filter((c) =>
+					(c[0] as string).includes("/exec"),
+				);
+				expect(claimCalls.length).toBe(0);
+				expect(execCalls.length).toBe(0);
+			}, 10000);
 		});
 	});
 

--- a/tests/pool.test.ts
+++ b/tests/pool.test.ts
@@ -135,18 +135,21 @@ describe("SandboxPool", () => {
 
 			it("warms pool pods when waitUntilReady is true (default)", async () => {
 				const mockFetch = vi.mocked(fetch);
-				// 1. POST create pool — already has ready replicas so no
-				//    refresh-poll iterations needed.
+				// 1. POST create pool — already has ready replicas.
 				mockFetch.mockResolvedValueOnce(mockResponse(readyPoolData));
-				// 2. POST claim sandbox from pool.
+				// 2. GET pool — warmPoolPods refreshes BEFORE the first
+				//    sleep so an already-ready pool is detected immediately
+				//    without burning a 2s poll interval.
+				mockFetch.mockResolvedValueOnce(mockResponse(readyPoolData));
+				// 3. POST claim sandbox from pool.
 				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-warm", status: "Running" }));
-				// 3. GET sandbox (waitUntilReady -> refresh).
+				// 4. GET sandbox (waitUntilReady -> refresh).
 				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-warm", status: "Running" }));
-				// 4. POST /exec — warmup probe echoing marker.
+				// 5. POST /exec — warmup probe echoing marker.
 				mockFetch.mockImplementationOnce(async (_url, init) =>
 					probeRespond((init as RequestInit).body as string),
 				);
-				// 5. DELETE sandbox (kill probe sbx).
+				// 6. DELETE sandbox (kill probe sbx).
 				mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
 
 				const pool = await SandboxPool.create({

--- a/tests/pool.test.ts
+++ b/tests/pool.test.ts
@@ -208,13 +208,17 @@ describe("SandboxPool", () => {
 				const mockFetch = vi.mocked(fetch);
 				// 1. POST create pool — already ready.
 				mockFetch.mockResolvedValueOnce(mockResponse(readyPoolData));
-				// 2. POST claim.
-				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-warm", status: "Running" }));
-				// 3+. Every subsequent call returns either a Running status
-				//     for GET refresh, or an empty-stdout result for /exec,
-				//     or a 204 for DELETE. The probe will never see the
-				//     marker and will time out, but the outer create must
-				//     still resolve.
+				// 2+. Every subsequent call routes by URL/method:
+				//   - GET on a sandbox-pools URL → return the ready pool
+				//     (warmPoolPods refreshes before claiming).
+				//   - POST claim → return a Running sandbox.
+				//   - GET on a sandbox URL → return Running for the
+				//     waitUntilReady refresh inside the probe.
+				//   - POST /exec → return empty stdout so the probe never
+				//     sees its marker and the warmup deadline trips.
+				//   - DELETE → 204 for kill().
+				// The probe should time out but the outer create must
+				// still resolve.
 				mockFetch.mockImplementation(async (url, init) => {
 					const u = url as string;
 					const method = (init as RequestInit | undefined)?.method ?? "GET";
@@ -230,6 +234,13 @@ describe("SandboxPool", () => {
 							session_id: "sess-warm",
 						});
 					}
+					if (u.includes("/sandbox-pools")) {
+						return mockResponse(readyPoolData);
+					}
+					if (u.includes("/sandboxes/claim")) {
+						return mockResponse({ name: "sb-warm", status: "Running" });
+					}
+					// GET on a sandbox URL — used by Sandbox.refresh().
 					return mockResponse({ name: "sb-warm", status: "Running" });
 				});
 


### PR DESCRIPTION
Implements #13 (Option A: single-pod probe at create time). TS pendant to prokube/prokube-sdk#24.

## Changes
- `CreatePoolOptions` gains `waitUntilReady?: boolean` (default true) and `readyTimeout?: number` (seconds, default 300)
- When true (default): poll pool readiness, claim one sandbox, run the existing warmup probe via `sbx.waitUntilReady()`, kill it
- When false: preserves today's instant-return behaviour
- On warmup timeout: logs a warning and returns the pool anyway

## Out of scope
- `Sandbox.fromPool` is unchanged - the hot path stays fast
- `Sandbox.waitUntilReady` / `warmupKernel` are unchanged - reuses the existing probe
- No backend changes

## Tests
- warms pool pods (happy path)
- opt-out via waitUntilReady=false
- best-effort on probe timeout

Closes #13