### PR TITLE
fix: build dist for git installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,14 +21,13 @@
 	"files": ["dist"],
 	"scripts": {
 		"build": "tsup",
-		"prepare": "npm run build",
+		"prepare": "tsup",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"lint": "biome check .",
 		"lint:fix": "biome check --write .",
 		"format": "biome format --write .",
-		"typecheck": "tsc --noEmit",
-		"prepublishOnly": "npm run build"
+		"typecheck": "tsc --noEmit"
 	},
 	"keywords": ["prokube", "sandbox", "ai", "ml", "kubernetes", "sdk"],
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	"files": ["dist"],
 	"scripts": {
 		"build": "tsup",
-		"prepare": "tsup",
+		"prepare": "node ./scripts/prepare.mjs",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"lint": "biome check .",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 	"files": ["dist"],
 	"scripts": {
 		"build": "tsup",
+		"prepare": "npm run build",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"lint": "biome check .",

--- a/scripts/prepare.mjs
+++ b/scripts/prepare.mjs
@@ -8,7 +8,13 @@ if (!packageManagerExec) {
 	);
 }
 
-const result = spawnSync(process.execPath, [packageManagerExec, "run", "build"], {
+const isNodeEntrypoint = /\.(?:c|m)?js$/i.test(packageManagerExec);
+const command = isNodeEntrypoint ? process.execPath : packageManagerExec;
+const args = isNodeEntrypoint
+	? [packageManagerExec, "run", "build"]
+	: ["run", "build"];
+
+const result = spawnSync(command, args, {
 	stdio: "inherit",
 });
 

--- a/scripts/prepare.mjs
+++ b/scripts/prepare.mjs
@@ -1,10 +1,35 @@
 import { spawnSync } from "node:child_process";
-const result = spawnSync(process.execPath, ["--run", "build"], {
+
+const packageManagerExec = process.env.npm_execpath;
+
+if (!packageManagerExec) {
+	throw new Error(
+		"Prepare failed because the package manager executable could not be determined from npm_execpath.",
+	);
+}
+
+const result = spawnSync(process.execPath, [packageManagerExec, "run", "build"], {
 	stdio: "inherit",
 });
 
-if (result.status !== 0) {
+if (result.error || result.signal || result.status !== 0) {
+	const details = [];
+
+	if (result.error) {
+		details.push(`spawn error: ${result.error.message}`);
+	}
+
+	if (result.signal) {
+		details.push(`terminated by signal: ${result.signal}`);
+	}
+
+	if (result.status !== null && result.status !== 0) {
+		details.push(`exit status: ${result.status}`);
+	}
+
+	const detailMessage = details.length > 0 ? ` (${details.join(", ")})` : "";
+
 	throw new Error(
-		"Prepare failed while running the build script. Ensure the git-based install includes the required build toolchain.",
+		`Prepare failed while running the build script${detailMessage}. Ensure the git-based install includes the required build toolchain.`,
 	);
 }

--- a/scripts/prepare.mjs
+++ b/scripts/prepare.mjs
@@ -1,0 +1,10 @@
+import { spawnSync } from "node:child_process";
+const result = spawnSync(process.execPath, ["--run", "build"], {
+	stdio: "inherit",
+});
+
+if (result.status !== 0) {
+	throw new Error(
+		"Prepare failed while running the build script. Ensure the git-based install includes the required build toolchain.",
+	);
+}


### PR DESCRIPTION
## Summary
- add a `prepare` script so git-based installs build `dist/`
- rely on `prepare` for build output during both git-based installs and npm publish

## Testing
- `npm run build`
- `npm install git+file:///Users/henrik/local-repos/prokube/prokube-sdk-ts/worktrees/issue-15`

Closes #15