### PR TITLE
fix: validate generated declaration output

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"build": "tsup",
 		"prepare": "node ./scripts/prepare.mjs",
 		"check:dts": "node ./scripts/check-dts.mjs",
-		"postbuild": "npm run check:dts",
+		"postbuild": "node ./scripts/check-dts.mjs",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"lint": "biome check .",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
 	"scripts": {
 		"build": "tsup",
 		"prepare": "node ./scripts/prepare.mjs",
+		"check:dts": "node ./scripts/check-dts.mjs",
+		"postbuild": "npm run check:dts",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"lint": "biome check .",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"build": "tsup",
 		"prepare": "node ./scripts/prepare.mjs",
 		"check:dts": "node ./scripts/check-dts.mjs",
-		"postbuild": "node --run check:dts",
+		"postbuild": "npm run check:dts",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"lint": "biome check .",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"build": "tsup",
 		"prepare": "node ./scripts/prepare.mjs",
 		"check:dts": "node ./scripts/check-dts.mjs",
-		"postbuild": "node ./scripts/check-dts.mjs",
+		"postbuild": "node --run check:dts",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"lint": "biome check .",

--- a/scripts/check-dts-lib.mjs
+++ b/scripts/check-dts-lib.mjs
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+export const declarationFiles = ["dist/index.d.ts", "dist/index.d.cts"];
+
+const relativeImportPatterns = [
+	/from\s+["'](\.{1,2}\/[^"']+)["']/g,
+	/import\s+["'](\.{1,2}\/[^"']+)["']/g,
+	/import\(\s*["'](\.{1,2}\/[^"']+)["']\s*\)/g,
+];
+
+export function findRelativeSpecifiers(source) {
+	const specifiers = new Set();
+
+	for (const pattern of relativeImportPatterns) {
+		for (const match of source.matchAll(pattern)) {
+			specifiers.add(match[1]);
+		}
+	}
+
+	return [...specifiers];
+}
+
+export function getDeclarationCandidatePaths(baseDir, specifier) {
+	const candidate = resolve(baseDir, specifier);
+	const includesDeclarationExtension = /\.d\.(?:cts|ts)$/.test(specifier);
+	const strippedCandidate = candidate.replace(/\.(?:mjs|cjs|js)$/, "");
+	const hasRuntimeExtension = strippedCandidate !== candidate;
+
+	return [
+		...(includesDeclarationExtension ? [candidate] : []),
+		`${candidate}.d.ts`,
+		`${candidate}.d.cts`,
+		resolve(candidate, "index.d.ts"),
+		resolve(candidate, "index.d.cts"),
+		...(hasRuntimeExtension
+			? [
+					`${strippedCandidate}.d.ts`,
+					`${strippedCandidate}.d.cts`,
+					resolve(strippedCandidate, "index.d.ts"),
+					resolve(strippedCandidate, "index.d.cts"),
+				]
+			: []),
+	];
+}
+
+export function validateDeclarationFile(file) {
+	if (!existsSync(file)) {
+		throw new Error(
+			`Missing declaration file: ${file}. Ensure the build produced the expected declaration output before running this check.`,
+		);
+	}
+
+	const source = readFileSync(file, "utf8");
+	const baseDir = dirname(resolve(file));
+
+	for (const specifier of findRelativeSpecifiers(source)) {
+		const paths = getDeclarationCandidatePaths(baseDir, specifier);
+
+		if (![...new Set(paths)].some((path) => existsSync(path))) {
+			throw new Error(`Broken declaration import in ${file}: ${specifier}`);
+		}
+	}
+}

--- a/scripts/check-dts-lib.mjs
+++ b/scripts/check-dts-lib.mjs
@@ -1,13 +1,54 @@
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
-
-export const declarationFiles = ["dist/index.d.ts", "dist/index.d.cts"];
+import { dirname, relative, resolve, sep } from "node:path";
 
 const relativeImportPatterns = [
 	/from\s+["'](\.{1,2}\/[^"']+)["']/g,
 	/import\s+["'](\.{1,2}\/[^"']+)["']/g,
 	/import\(\s*["'](\.{1,2}\/[^"']+)["']\s*\)/g,
 ];
+
+function collectTypesFromExports(exportsField, declarationFiles) {
+	if (!exportsField || typeof exportsField !== "object") {
+		return;
+	}
+
+	if (Array.isArray(exportsField)) {
+		for (const entry of exportsField) {
+			collectTypesFromExports(entry, declarationFiles);
+		}
+		return;
+	}
+
+	for (const [key, value] of Object.entries(exportsField)) {
+		if (key === "types" && typeof value === "string") {
+			declarationFiles.add(value);
+			continue;
+		}
+
+		collectTypesFromExports(value, declarationFiles);
+	}
+}
+
+export function getDeclarationFilesFromPackageJson(packageJsonPath = resolve("package.json")) {
+	const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+	const files = new Set();
+
+	if (typeof packageJson.types === "string") {
+		files.add(packageJson.types);
+	}
+
+	collectTypesFromExports(packageJson.exports, files);
+
+	if (files.size === 0) {
+		throw new Error(
+			`No declaration entrypoints were found in ${packageJsonPath}. Declare them via "types" and/or "exports.*.types".`,
+		);
+	}
+
+	return [...files];
+}
+
+export const declarationFiles = getDeclarationFilesFromPackageJson();
 
 export function findRelativeSpecifiers(source) {
 	const specifiers = new Set();
@@ -44,7 +85,25 @@ export function getDeclarationCandidatePaths(baseDir, specifier) {
 	];
 }
 
-export function validateDeclarationFile(file) {
+function isWithinRoot(path, root) {
+	return path === root || path.startsWith(`${root}${sep}`);
+}
+
+export function getDeclarationRoot(file, packageRoot = resolve(".")) {
+	const absoluteFile = resolve(file);
+	const relativeFile = relative(packageRoot, absoluteFile);
+	const [rootSegment] = relativeFile.split(sep);
+
+	if (!rootSegment || rootSegment === "..") {
+		throw new Error(
+			`Cannot determine declaration root for ${file} relative to ${packageRoot}.`,
+		);
+	}
+
+	return resolve(packageRoot, rootSegment);
+}
+
+export function validateDeclarationFile(file, declarationRoot = getDeclarationRoot(file)) {
 	if (!existsSync(file)) {
 		throw new Error(
 			`Missing declaration file: ${file}. Ensure the build produced the expected declaration output before running this check.`,
@@ -56,8 +115,11 @@ export function validateDeclarationFile(file) {
 
 	for (const specifier of findRelativeSpecifiers(source)) {
 		const paths = getDeclarationCandidatePaths(baseDir, specifier);
+		const validPaths = [...new Set(paths)].filter((path) =>
+			isWithinRoot(path, declarationRoot),
+		);
 
-		if (![...new Set(paths)].some((path) => existsSync(path))) {
+		if (!validPaths.some((path) => existsSync(path))) {
 			throw new Error(`Broken declaration import in ${file}: ${specifier}`);
 		}
 	}

--- a/scripts/check-dts-lib.mjs
+++ b/scripts/check-dts-lib.mjs
@@ -48,8 +48,6 @@ export function getDeclarationFilesFromPackageJson(packageJsonPath = resolve("pa
 	return [...files];
 }
 
-export const declarationFiles = getDeclarationFilesFromPackageJson();
-
 export function findRelativeSpecifiers(source) {
 	const specifiers = new Set();
 
@@ -68,8 +66,11 @@ export function getDeclarationCandidatePaths(baseDir, specifier) {
 	const strippedCandidate = candidate.replace(/\.(?:mjs|cjs|js)$/, "");
 	const hasRuntimeExtension = strippedCandidate !== candidate;
 
+	if (includesDeclarationExtension) {
+		return [candidate];
+	}
+
 	return [
-		...(includesDeclarationExtension ? [candidate] : []),
 		`${candidate}.d.ts`,
 		`${candidate}.d.cts`,
 		resolve(candidate, "index.d.ts"),
@@ -91,16 +92,26 @@ function isWithinRoot(path, root) {
 
 export function getDeclarationRoot(file, packageRoot = resolve(".")) {
 	const absoluteFile = resolve(file);
-	const relativeFile = relative(packageRoot, absoluteFile);
+	const resolvedPackageRoot = resolve(packageRoot);
+	const relativeFile = relative(resolvedPackageRoot, absoluteFile);
 	const [rootSegment] = relativeFile.split(sep);
 
-	if (!rootSegment || rootSegment === "..") {
+	if (
+		!rootSegment ||
+		rootSegment === ".." ||
+		relativeFile.startsWith(`..${sep}`) ||
+		relativeFile === ".."
+	) {
 		throw new Error(
 			`Cannot determine declaration root for ${file} relative to ${packageRoot}.`,
 		);
 	}
 
-	return resolve(packageRoot, rootSegment);
+	if (!relativeFile.includes(sep)) {
+		return resolvedPackageRoot;
+	}
+
+	return resolve(resolvedPackageRoot, rootSegment);
 }
 
 export function validateDeclarationFile(file, declarationRoot = getDeclarationRoot(file)) {

--- a/scripts/check-dts.mjs
+++ b/scripts/check-dts.mjs
@@ -5,21 +5,37 @@ const declarationFiles = ["dist/index.d.ts", "dist/index.d.cts"];
 const relativeImportPattern = /from\s+["'](\.{1,2}\/[^"']+)["']/g;
 
 for (const file of declarationFiles) {
+	if (!existsSync(file)) {
+		throw new Error(
+			`Missing declaration file: ${file}. Ensure the build produced the expected declaration output before running this check.`,
+		);
+	}
+
 	const source = readFileSync(file, "utf8");
 	const baseDir = dirname(resolve(file));
 
 	for (const match of source.matchAll(relativeImportPattern)) {
 		const specifier = match[1];
 		const candidate = resolve(baseDir, specifier);
+		const strippedCandidate = candidate.replace(/\.(?:mjs|cjs|js)$/, "");
+		const hasRuntimeExtension = strippedCandidate !== candidate;
 		const paths = [
 			candidate,
 			`${candidate}.d.ts`,
 			`${candidate}.d.cts`,
 			resolve(candidate, "index.d.ts"),
 			resolve(candidate, "index.d.cts"),
+			...(hasRuntimeExtension
+				? [
+						`${strippedCandidate}.d.ts`,
+						`${strippedCandidate}.d.cts`,
+						resolve(strippedCandidate, "index.d.ts"),
+						resolve(strippedCandidate, "index.d.cts"),
+					]
+				: []),
 		];
 
-		if (!paths.some((path) => existsSync(path))) {
+		if (![...new Set(paths)].some((path) => existsSync(path))) {
 			throw new Error(`Broken declaration import in ${file}: ${specifier}`);
 		}
 	}

--- a/scripts/check-dts.mjs
+++ b/scripts/check-dts.mjs
@@ -1,45 +1,7 @@
-import { existsSync, readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
-
-const declarationFiles = ["dist/index.d.ts", "dist/index.d.cts"];
-const relativeImportPattern = /from\s+["'](\.{1,2}\/[^"']+)["']/g;
+import { declarationFiles, validateDeclarationFile } from "./check-dts-lib.mjs";
 
 for (const file of declarationFiles) {
-	if (!existsSync(file)) {
-		throw new Error(
-			`Missing declaration file: ${file}. Ensure the build produced the expected declaration output before running this check.`,
-		);
-	}
-
-	const source = readFileSync(file, "utf8");
-	const baseDir = dirname(resolve(file));
-
-	for (const match of source.matchAll(relativeImportPattern)) {
-		const specifier = match[1];
-		const candidate = resolve(baseDir, specifier);
-		const includesDeclarationExtension = /\.d\.(?:cts|ts)$/.test(specifier);
-		const strippedCandidate = candidate.replace(/\.(?:mjs|cjs|js)$/, "");
-		const hasRuntimeExtension = strippedCandidate !== candidate;
-		const paths = [
-			...(includesDeclarationExtension ? [candidate] : []),
-			`${candidate}.d.ts`,
-			`${candidate}.d.cts`,
-			resolve(candidate, "index.d.ts"),
-			resolve(candidate, "index.d.cts"),
-			...(hasRuntimeExtension
-				? [
-						`${strippedCandidate}.d.ts`,
-						`${strippedCandidate}.d.cts`,
-						resolve(strippedCandidate, "index.d.ts"),
-						resolve(strippedCandidate, "index.d.cts"),
-					]
-				: []),
-		];
-
-		if (![...new Set(paths)].some((path) => existsSync(path))) {
-			throw new Error(`Broken declaration import in ${file}: ${specifier}`);
-		}
-	}
+	validateDeclarationFile(file);
 }
 
 console.log("Declaration imports resolve correctly.");

--- a/scripts/check-dts.mjs
+++ b/scripts/check-dts.mjs
@@ -1,0 +1,28 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const declarationFiles = ["dist/index.d.ts", "dist/index.d.cts"];
+const relativeImportPattern = /from\s+["'](\.{1,2}\/[^"']+)["']/g;
+
+for (const file of declarationFiles) {
+	const source = readFileSync(file, "utf8");
+	const baseDir = dirname(resolve(file));
+
+	for (const match of source.matchAll(relativeImportPattern)) {
+		const specifier = match[1];
+		const candidate = resolve(baseDir, specifier);
+		const paths = [
+			candidate,
+			`${candidate}.d.ts`,
+			`${candidate}.d.cts`,
+			resolve(candidate, "index.d.ts"),
+			resolve(candidate, "index.d.cts"),
+		];
+
+		if (!paths.some((path) => existsSync(path))) {
+			throw new Error(`Broken declaration import in ${file}: ${specifier}`);
+		}
+	}
+}
+
+console.log("Declaration imports resolve correctly.");

--- a/scripts/check-dts.mjs
+++ b/scripts/check-dts.mjs
@@ -17,10 +17,11 @@ for (const file of declarationFiles) {
 	for (const match of source.matchAll(relativeImportPattern)) {
 		const specifier = match[1];
 		const candidate = resolve(baseDir, specifier);
+		const includesDeclarationExtension = /\.d\.(?:cts|ts)$/.test(specifier);
 		const strippedCandidate = candidate.replace(/\.(?:mjs|cjs|js)$/, "");
 		const hasRuntimeExtension = strippedCandidate !== candidate;
 		const paths = [
-			candidate,
+			...(includesDeclarationExtension ? [candidate] : []),
 			`${candidate}.d.ts`,
 			`${candidate}.d.cts`,
 			resolve(candidate, "index.d.ts"),

--- a/scripts/check-dts.mjs
+++ b/scripts/check-dts.mjs
@@ -1,6 +1,9 @@
-import { declarationFiles, validateDeclarationFile } from "./check-dts-lib.mjs";
+import {
+	getDeclarationFilesFromPackageJson,
+	validateDeclarationFile,
+} from "./check-dts-lib.mjs";
 
-for (const file of declarationFiles) {
+for (const file of getDeclarationFilesFromPackageJson()) {
 	validateDeclarationFile(file);
 }
 

--- a/tests/check-dts.test.ts
+++ b/tests/check-dts.test.ts
@@ -1,0 +1,75 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+	findRelativeSpecifiers,
+	validateDeclarationFile,
+} from "../scripts/check-dts-lib.mjs";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { force: true, recursive: true });
+	}
+});
+
+function createTempDir() {
+	const dir = mkdtempSync(join(tmpdir(), "prokube-check-dts-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+describe("check-dts helpers", () => {
+	it("finds relative specifiers across declaration import forms", () => {
+		const source = `
+			export { Foo } from "./foo.js";
+			import "./bar.js";
+			type Baz = import("../baz.js").Baz;
+		`;
+
+		expect(findRelativeSpecifiers(source)).toEqual([
+			"./foo.js",
+			"./bar.js",
+			"../baz.js",
+		]);
+	});
+
+	it("accepts runtime extensions that map to declaration files", () => {
+		const dir = createTempDir();
+		const declarationFile = join(dir, "index.d.ts");
+
+		writeFileSync(declarationFile, 'export { Foo } from "./foo.js";');
+		writeFileSync(join(dir, "foo.d.ts"), "export interface Foo {}\n");
+
+		expect(() => validateDeclarationFile(declarationFile)).not.toThrow();
+	});
+
+	it("checks import type queries and side-effect imports", () => {
+		const dir = createTempDir();
+		const declarationFile = join(dir, "index.d.ts");
+
+		writeFileSync(
+			declarationFile,
+			'type Foo = import("./types.js").Foo;\nimport "./setup.js";\n',
+		);
+		writeFileSync(join(dir, "types.d.ts"), "export interface Foo {}\n");
+		writeFileSync(join(dir, "setup.d.ts"), "export {}\n");
+
+		expect(() => validateDeclarationFile(declarationFile)).not.toThrow();
+	});
+
+	it("does not treat bare directories as valid declaration targets", () => {
+		const dir = createTempDir();
+		const declarationFile = join(dir, "index.d.ts");
+
+		writeFileSync(declarationFile, 'export { Foo } from "./foo";');
+		mkdirSync(join(dir, "foo"));
+
+		expect(() => validateDeclarationFile(declarationFile)).toThrow(
+			`Broken declaration import in ${declarationFile}: ./foo`,
+		);
+	});
+});

--- a/tests/check-dts.test.ts
+++ b/tests/check-dts.test.ts
@@ -1,11 +1,13 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
 	findRelativeSpecifiers,
+	getDeclarationCandidatePaths,
 	getDeclarationFilesFromPackageJson,
+	getDeclarationRoot,
 	validateDeclarationFile,
 } from "../scripts/check-dts-lib.mjs";
 
@@ -62,6 +64,12 @@ describe("check-dts helpers", () => {
 		expect(() => validateDeclarationFile(declarationFile, dir)).not.toThrow();
 	});
 
+	it("keeps explicit declaration specifiers exact", () => {
+		const paths = getDeclarationCandidatePaths("/tmp/dist", "./foo.d.ts");
+
+		expect(paths).toEqual([resolve("/tmp/dist", "./foo.d.ts")]);
+	});
+
 	it("rejects imports that escape the published declaration root", () => {
 		const dir = createTempDir();
 		const distDir = join(dir, "dist");
@@ -114,5 +122,14 @@ describe("check-dts helpers", () => {
 			"./dist/index.d.ts",
 			"./dist/index.d.cts",
 		]);
+	});
+
+	it("uses the package root for root-level declaration files", () => {
+		const dir = createTempDir();
+		const declarationFile = join(dir, "index.d.ts");
+
+		writeFileSync(declarationFile, "export interface Root {}\n");
+
+		expect(getDeclarationRoot(declarationFile, dir)).toBe(dir);
 	});
 });

--- a/tests/check-dts.test.ts
+++ b/tests/check-dts.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
 	findRelativeSpecifiers,
+	getDeclarationFilesFromPackageJson,
 	validateDeclarationFile,
 } from "../scripts/check-dts-lib.mjs";
 
@@ -44,7 +45,7 @@ describe("check-dts helpers", () => {
 		writeFileSync(declarationFile, 'export { Foo } from "./foo.js";');
 		writeFileSync(join(dir, "foo.d.ts"), "export interface Foo {}\n");
 
-		expect(() => validateDeclarationFile(declarationFile)).not.toThrow();
+		expect(() => validateDeclarationFile(declarationFile, dir)).not.toThrow();
 	});
 
 	it("checks import type queries and side-effect imports", () => {
@@ -58,7 +59,22 @@ describe("check-dts helpers", () => {
 		writeFileSync(join(dir, "types.d.ts"), "export interface Foo {}\n");
 		writeFileSync(join(dir, "setup.d.ts"), "export {}\n");
 
-		expect(() => validateDeclarationFile(declarationFile)).not.toThrow();
+		expect(() => validateDeclarationFile(declarationFile, dir)).not.toThrow();
+	});
+
+	it("rejects imports that escape the published declaration root", () => {
+		const dir = createTempDir();
+		const distDir = join(dir, "dist");
+		const declarationFile = join(distDir, "index.d.ts");
+
+		mkdirSync(distDir);
+		writeFileSync(declarationFile, 'export { Foo } from "../src/foo.js";');
+		mkdirSync(join(dir, "src"));
+		writeFileSync(join(dir, "src", "foo.d.ts"), "export interface Foo {}\n");
+
+		expect(() => validateDeclarationFile(declarationFile, distDir)).toThrow(
+			`Broken declaration import in ${declarationFile}: ../src/foo.js`,
+		);
 	});
 
 	it("does not treat bare directories as valid declaration targets", () => {
@@ -68,8 +84,35 @@ describe("check-dts helpers", () => {
 		writeFileSync(declarationFile, 'export { Foo } from "./foo";');
 		mkdirSync(join(dir, "foo"));
 
-		expect(() => validateDeclarationFile(declarationFile)).toThrow(
+		expect(() => validateDeclarationFile(declarationFile, dir)).toThrow(
 			`Broken declaration import in ${declarationFile}: ./foo`,
 		);
+	});
+
+	it("collects declaration entrypoints from package.json metadata", () => {
+		const dir = createTempDir();
+		const packageJsonPath = join(dir, "package.json");
+
+		writeFileSync(
+			packageJsonPath,
+			JSON.stringify(
+				{
+					types: "./dist/index.d.ts",
+					exports: {
+						".": {
+							import: { types: "./dist/index.d.ts" },
+							require: { types: "./dist/index.d.cts" },
+						},
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		expect(getDeclarationFilesFromPackageJson(packageJsonPath)).toEqual([
+			"./dist/index.d.ts",
+			"./dist/index.d.cts",
+		]);
 	});
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsup";
 export default defineConfig({
 	entry: ["src/index.ts"],
 	format: ["esm", "cjs"],
-	dts: true,
+	dts: { resolve: true },
 	clean: true,
 	sourcemap: true,
 	target: "es2022",


### PR DESCRIPTION
## Summary
- enable resolved DTS output in tsup
- add a declaration validation script that fails the build on broken relative type imports
- run the validation automatically after build

## Testing
- `npm run build`

Closes #16