### PR TITLE
fix: ship prebuilt SDK release tarballs

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,40 @@
+name: Release Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build SDK
+        run: npm run build
+
+      - name: Pack release tarball
+        run: npm pack --pack-destination ./.artifacts
+
+      - name: Upload release asset
+        if: github.event_name == 'release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" ./.artifacts/*.tgz
+
+      - name: Upload workflow artifact
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-package
+          path: ./.artifacts/*.tgz

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   package:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -28,11 +28,15 @@ jobs:
       - name: Pack release tarball
         run: npm pack --pack-destination ./.artifacts
 
+      - name: Prepare tagged release asset
+        if: github.event_name == 'release'
+        run: cp ./.artifacts/*.tgz "./.artifacts/prokube-${{ github.event.release.tag_name }}.tgz"
+
       - name: Upload release asset
         if: github.event_name == 'release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.event.release.tag_name }}" ./.artifacts/*.tgz
+        run: gh release upload "${{ github.event.release.tag_name }}" "./.artifacts/prokube-${{ github.event.release.tag_name }}.tgz"
 
       - name: Upload workflow artifact
         if: github.event_name != 'release'

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -25,6 +25,15 @@ jobs:
       - name: Build SDK
         run: npm run build
 
+      - name: Validate release tag
+        if: github.event_name == 'release'
+        run: |
+          expected_tag=$(node -e 'const version = require("./package.json").version; const [year, month, day] = version.split("."); console.log(`v${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`);')
+          if [ "$expected_tag" != "${{ github.event.release.tag_name }}" ]; then
+            echo "Expected release tag $expected_tag but got ${{ github.event.release.tag_name }}" >&2
+            exit 1
+          fi
+
       - name: Pack release tarball
         run: npm pack --pack-destination ./.artifacts
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ coverage/
 *.log
 .env
 .env.*
+.artifacts/
+.tmp-release-consumer/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ default, so installing from source can leave `dist/` missing unless the package
 is explicitly trusted.
 
 ```bash
+# Replace v0.1.0 with the desired release tag; note the filename drops the 'v' prefix
 bun add https://github.com/prokube/prokube-sdk-ts/releases/download/v0.1.0/prokube-0.1.0.tgz
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,31 @@ TypeScript SDK for the [prokube.ai](https://prokube.ai) sandbox platform.
 ## Installation
 
 ```bash
-# From GitHub
-npm install prokube/prokube-sdk-ts
+# From npm/GitHub Packages when published
+npm install prokube
 
 # For development
 git clone https://github.com/prokube/prokube-sdk-ts.git
 cd prokube-sdk-ts
 npm install
+```
+
+For Bun consumers and Docker builds, prefer the prebuilt release tarball over a
+GitHub source dependency. Bun does not run git dependency lifecycle scripts by
+default, so installing from source can leave `dist/` missing unless the package
+is explicitly trusted.
+
+```bash
+bun add https://github.com/prokube/prokube-sdk-ts/releases/download/v0.1.0/prokube-0.1.0.tgz
+```
+
+Each GitHub release publishes a packed `.tgz` built from the SDK's `dist/`
+output, so consumers do not need to run `prepare` or rebuild inside Docker.
+
+To validate the release package path locally, run:
+
+```bash
+npm run smoke:release
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ default, so installing from source can leave `dist/` missing unless the package
 is explicitly trusted.
 
 ```bash
-# Replace v0.1.0 with the desired release tag; note the filename drops the 'v' prefix
-bun add https://github.com/prokube/prokube-sdk-ts/releases/download/v0.1.0/prokube-0.1.0.tgz
+# Replace v23-04-26 with the desired release tag
+bun add https://github.com/prokube/prokube-sdk-ts/releases/download/v23-04-26/prokube-v23-04-26.tgz
 ```
 
 Each GitHub release publishes a packed `.tgz` built from the SDK's `dist/`
 output, so consumers do not need to run `prepare` or rebuild inside Docker.
+The GitHub release tag and uploaded asset name can be date-based, for example
+`v23-04-26`.
 
 To validate the release package path locally, run:
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ default, so installing from source can leave `dist/` missing unless the package
 is explicitly trusted.
 
 ```bash
-# Replace v23-04-26 with the desired release tag
-bun add https://github.com/prokube/prokube-sdk-ts/releases/download/v23-04-26/prokube-v23-04-26.tgz
+# Replace v2026-04-24 with the desired release tag
+bun add https://github.com/prokube/prokube-sdk-ts/releases/download/v2026-04-24/prokube-v2026-04-24.tgz
 ```
 
 Each GitHub release publishes a packed `.tgz` built from the SDK's `dist/`
 output, so consumers do not need to run `prepare` or rebuild inside Docker.
-The GitHub release tag and uploaded asset name can be date-based, for example
-`v23-04-26`.
+This repo uses date-based package versions such as `2026.4.24`, with matching
+GitHub release tags and asset names such as `v2026-04-24` and
+`prokube-v2026-04-24.tgz`.
 
 To validate the release package path locally, run:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prokube",
-	"version": "0.1.0",
+	"version": "2026.4.24",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prokube",
-			"version": "0.1.0",
+			"version": "2026.4.24",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^25.5.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
 		"build": "node ./scripts/build.mjs",
 		"prepare": "node ./scripts/build.mjs",
 		"check:dts": "node ./scripts/check-dts.mjs",
+		"pack:release": "npm run build && npm pack --pack-destination ./.artifacts",
+		"smoke:release": "node ./scripts/smoke-release.mjs",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"lint": "biome check .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prokube",
-	"version": "0.1.0",
+	"version": "2026.4.24",
 	"description": "TypeScript SDK for the prokube.ai sandbox platform",
 	"type": "module",
 	"main": "./dist/index.cjs",
@@ -18,7 +18,9 @@
 			}
 		}
 	},
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build": "node ./scripts/build.mjs",
 		"prepare": "node ./scripts/build.mjs",
@@ -32,7 +34,14 @@
 		"format": "biome format --write .",
 		"typecheck": "tsc --noEmit"
 	},
-	"keywords": ["prokube", "sandbox", "ai", "ml", "kubernetes", "sdk"],
+	"keywords": [
+		"prokube",
+		"sandbox",
+		"ai",
+		"ml",
+		"kubernetes",
+		"sdk"
+	],
 	"license": "MIT",
 	"engines": {
 		"node": ">=20.19.0"

--- a/scripts/smoke-release.mjs
+++ b/scripts/smoke-release.mjs
@@ -1,0 +1,43 @@
+import { mkdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const artifactsDir = path.join(repoRoot, ".artifacts");
+const packageJson = JSON.parse(
+  readFileSync(path.join(repoRoot, "package.json"), "utf8"),
+);
+const tarballName = `${packageJson.name}-${packageJson.version}.tgz`;
+const tarballPath = path.join(artifactsDir, tarballName);
+
+mkdirSync(artifactsDir, { recursive: true });
+
+execFileSync("npm", ["run", "pack:release"], {
+  cwd: repoRoot,
+  stdio: "inherit",
+});
+
+execFileSync(
+  "docker",
+  [
+    "build",
+    "--no-cache",
+    "--build-arg",
+    `PACKAGE_TGZ=${path.relative(repoRoot, tarballPath)}`,
+    "-f",
+    path.join("tests", "smoke", "release-consumer", "Dockerfile"),
+    "-t",
+    `prokube-sdk-smoke:${Date.now()}`,
+    ".",
+  ],
+  {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      DOCKER_BUILDKIT: process.env.DOCKER_BUILDKIT ?? "1",
+    },
+  },
+);

--- a/tests/smoke/release-consumer/Dockerfile
+++ b/tests/smoke/release-consumer/Dockerfile
@@ -1,0 +1,14 @@
+FROM oven/bun:1
+
+ARG PACKAGE_TGZ
+
+WORKDIR /app
+
+COPY tests/smoke/release-consumer/package.json ./package.json
+COPY tests/smoke/release-consumer/tsconfig.json ./tsconfig.json
+COPY tests/smoke/release-consumer/index.ts ./index.ts
+COPY ${PACKAGE_TGZ} /tmp/prokube.tgz
+
+RUN bun install
+RUN bun run index.ts
+RUN bunx tsc --noEmit

--- a/tests/smoke/release-consumer/index.ts
+++ b/tests/smoke/release-consumer/index.ts
@@ -1,0 +1,21 @@
+import { Config, Sandbox, commandSuccess } from "prokube";
+
+const config = new Config({
+  apiUrl: "https://example.invalid/pkui",
+  workspace: "smoke-test",
+  apiKey: "test-key",
+});
+
+if (!config.useApiKey) {
+  throw new Error("Expected Config.useApiKey to be true");
+}
+
+if (typeof Sandbox.fromPool !== "function") {
+  throw new Error("Expected Sandbox.fromPool to be available");
+}
+
+if (!commandSuccess({ stdout: "", stderr: "", exitCode: 0, durationMs: 1 })) {
+  throw new Error("Expected commandSuccess helper to return true");
+}
+
+console.log("release consumer smoke test passed");

--- a/tests/smoke/release-consumer/package.json
+++ b/tests/smoke/release-consumer/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "prokube-release-consumer-smoke",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "prokube": "file:/tmp/prokube.tgz"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/tests/smoke/release-consumer/tsconfig.json
+++ b/tests/smoke/release-consumer/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds and uploads a packed SDK tarball for each GitHub release
- add a minimal Bun consumer smoke test, including a Docker-based smoke path, for installing the packed tarball without running dependency lifecycle scripts
- document the release tarball install path for Bun and Docker users and add helper scripts for packing and smoke-testing locally

## Testing
- npm run pack:release
- local Bun tarball consumer smoke: bun install, bun run index.ts, bunx tsc --noEmit
- note: the Docker-based smoke path is wired up via npm run smoke:release but could not be executed end-to-end here because the local Docker daemon was unavailable