### PR TITLE
fix: honor pool resume hint in SDK

### DIFF
--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -130,7 +130,11 @@ export class SandboxClient {
 		}
 	}
 
-	async resume(name: string): Promise<SandboxInfo> {
+	async resume(name: string): Promise<void> {
+		await this.resumeInfo(name);
+	}
+
+	async resumeInfo(name: string): Promise<SandboxInfo> {
 		try {
 			const data = (await this.http.post(this.sandboxSubPath(name, "resume"))) as Record<
 				string,

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -16,11 +16,13 @@ import {
 	type FileInfo,
 	type FileWriteInput,
 	type SandboxInfo,
+	SandboxStatus,
 	parseBatchFileWriteResponse,
 	parseCodeResult,
 	parseCommandResult,
 	parseFileInfo,
 	parseSandboxInfo,
+	parseStatus,
 } from "./models.js";
 
 const textEncoder = new TextEncoder();
@@ -128,9 +130,25 @@ export class SandboxClient {
 		}
 	}
 
-	async resume(name: string): Promise<void> {
+	async resume(name: string): Promise<SandboxInfo> {
 		try {
-			await this.http.post(this.sandboxSubPath(name, "resume"));
+			const data = (await this.http.post(this.sandboxSubPath(name, "resume"))) as Record<
+				string,
+				unknown
+			>;
+			const responseName = (data.name ?? data.sandboxName) as string | undefined;
+			if (responseName) return parseSandboxInfo(data, this.workspace);
+			const responseStatus = (data.status ?? data.phase) as string | undefined;
+
+			return {
+				name,
+				workspace: this.workspace,
+				status: responseStatus ? parseStatus(responseStatus) : SandboxStatus.Running,
+				image: data.image as string | undefined,
+				pool: (data.poolName ?? data.pool) as string | undefined,
+				createdAt: (data.createdAt ?? data.created_at) as string | undefined,
+				resumedFromPool: data.resumedFromPool === true,
+			};
 		} catch (e) {
 			if (e instanceof ProKubeError && e.statusCode === 409) {
 				throw new SandboxError(`Cannot resume sandbox '${name}': not in Paused state`, 409);
@@ -192,10 +210,7 @@ export class SandboxClient {
 		});
 	}
 
-	async writeFilesBatch(
-		name: string,
-		items: FileWriteInput[],
-	): Promise<BatchFileWriteResponse> {
+	async writeFilesBatch(name: string, items: FileWriteInput[]): Promise<BatchFileWriteResponse> {
 		const data = (await this.http.post(this.sandboxSubPath(name, "files/batch"), {
 			items: items.map((item) => ({
 				path: item.path,

--- a/src/sandbox/code.ts
+++ b/src/sandbox/code.ts
@@ -33,10 +33,12 @@ export class CodeRunner {
 	}
 
 	resetSession(): void {
+		this.sessionId = undefined;
 		this.resetOnNextExec = true;
 	}
 
 	markSessionInvalid(): void {
+		this.sessionId = undefined;
 		this.resetOnNextExec = true;
 	}
 

--- a/src/sandbox/code.ts
+++ b/src/sandbox/code.ts
@@ -38,8 +38,7 @@ export class CodeRunner {
 	}
 
 	markSessionInvalid(): void {
-		this.sessionId = undefined;
-		this.resetOnNextExec = true;
+		this.resetSession();
 	}
 
 	getSessionId(): string | undefined {

--- a/src/sandbox/models.ts
+++ b/src/sandbox/models.ts
@@ -15,6 +15,7 @@ export interface SandboxInfo {
 	image?: string;
 	pool?: string;
 	createdAt?: string;
+	resumedFromPool?: boolean;
 }
 
 export interface CodeResult {
@@ -151,6 +152,7 @@ export function parseSandboxInfo(data: Record<string, unknown>, workspace: strin
 		image: data.image as string | undefined,
 		pool: (data.poolName ?? data.pool) as string | undefined,
 		createdAt: (data.createdAt ?? data.created_at) as string | undefined,
+		resumedFromPool: data.resumedFromPool === true,
 	};
 }
 
@@ -186,9 +188,7 @@ export function parseFileInfo(data: Record<string, unknown>): FileInfo {
 	};
 }
 
-export function parseBatchFileWriteResponse(
-	data: Record<string, unknown>,
-): BatchFileWriteResponse {
+export function parseBatchFileWriteResponse(data: Record<string, unknown>): BatchFileWriteResponse {
 	if (data.results !== undefined && !Array.isArray(data.results)) {
 		throw new Error("Invalid API response: batch results must be an array");
 	}

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -226,7 +226,7 @@ export class Sandbox {
 
 	async resume(): Promise<void> {
 		this.checkNotKilled();
-		const info = await this._client.resume(this._name);
+		const info = await this._client.resumeInfo(this._name);
 		this._status = info.status;
 		if (info.image) this._image = info.image;
 		if (info.pool) this._pool = info.pool;

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -39,6 +39,7 @@ export class Sandbox {
 	private _image: string | undefined;
 	private _pool: string | undefined;
 	private _killed = false;
+	private _skipNextWarmup = false;
 
 	private readonly _timeout: number;
 
@@ -225,8 +226,11 @@ export class Sandbox {
 
 	async resume(): Promise<void> {
 		this.checkNotKilled();
-		await this._client.resume(this._name);
-		this._status = SandboxStatus.Running;
+		const info = await this._client.resume(this._name);
+		this._status = info.status;
+		if (info.image) this._image = info.image;
+		if (info.pool) this._pool = info.pool;
+		this._skipNextWarmup = info.resumedFromPool === true;
 		this._code.markSessionInvalid();
 	}
 
@@ -239,6 +243,10 @@ export class Sandbox {
 			await this.refresh();
 
 			if (this._status === SandboxStatus.Running) {
+				if (this._skipNextWarmup) {
+					this._skipNextWarmup = false;
+					return;
+				}
 				await this.warmupKernel(deadline);
 				return;
 			}

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -298,6 +298,7 @@ export class Sandbox {
 			const probeTimeoutSec = Math.min(maxProbeTimeoutSec, Math.floor(remainingMs / 1000));
 			const result = await this.runCode(probeCode, "python", probeTimeoutSec);
 			if (result.stdout.trim() === marker) return;
+			this._code.markSessionInvalid();
 
 			const postProbeRemainingMs = deadline - Date.now();
 			if (postProbeRemainingMs <= 0) break;

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -200,38 +200,47 @@ describe("SandboxClient", () => {
 			mockFetch.mockResolvedValue(mockResponse({}));
 
 			const client = new SandboxClient(makeConfig());
-			const result = await client.resume("sb-1");
+			await expect(client.resume("sb-1")).resolves.toBeUndefined();
 
 			const url = mockFetch.mock.calls[0][0] as string;
 			expect(url).toContain("/sandboxes/sb-1/resume");
-			expect(result.name).toBe("sb-1");
-			expect(result.status).toBe(SandboxStatus.Running);
-			expect(result.resumedFromPool).toBe(false);
 		});
 
-		it("resume parses pool resume hint", async () => {
+		it("resumeInfo parses pool resume hint", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(
 				mockResponse({ name: "sb-1", phase: "Running", resumedFromPool: true }),
 			);
 
 			const client = new SandboxClient(makeConfig());
-			const result = await client.resume("sb-1");
+			const result = await client.resumeInfo("sb-1");
 
 			expect(result.status).toBe(SandboxStatus.Running);
 			expect(result.resumedFromPool).toBe(true);
 		});
 
-		it("resume preserves non-running status from response", async () => {
+		it("resumeInfo preserves non-running status from response", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(
 				mockResponse({ name: "sb-1", phase: "Pending", resumedFromPool: false }),
 			);
 
 			const client = new SandboxClient(makeConfig());
-			const result = await client.resume("sb-1");
+			const result = await client.resumeInfo("sb-1");
 
 			expect(result.status).toBe(SandboxStatus.Pending);
+			expect(result.resumedFromPool).toBe(false);
+		});
+
+		it("resumeInfo handles legacy empty response", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({}));
+
+			const client = new SandboxClient(makeConfig());
+			const result = await client.resumeInfo("sb-1");
+
+			expect(result.name).toBe("sb-1");
+			expect(result.status).toBe(SandboxStatus.Running);
 			expect(result.resumedFromPool).toBe(false);
 		});
 

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -200,10 +200,39 @@ describe("SandboxClient", () => {
 			mockFetch.mockResolvedValue(mockResponse({}));
 
 			const client = new SandboxClient(makeConfig());
-			await client.resume("sb-1");
+			const result = await client.resume("sb-1");
 
 			const url = mockFetch.mock.calls[0][0] as string;
 			expect(url).toContain("/sandboxes/sb-1/resume");
+			expect(result.name).toBe("sb-1");
+			expect(result.status).toBe(SandboxStatus.Running);
+			expect(result.resumedFromPool).toBe(false);
+		});
+
+		it("resume parses pool resume hint", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(
+				mockResponse({ name: "sb-1", phase: "Running", resumedFromPool: true }),
+			);
+
+			const client = new SandboxClient(makeConfig());
+			const result = await client.resume("sb-1");
+
+			expect(result.status).toBe(SandboxStatus.Running);
+			expect(result.resumedFromPool).toBe(true);
+		});
+
+		it("resume preserves non-running status from response", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(
+				mockResponse({ name: "sb-1", phase: "Pending", resumedFromPool: false }),
+			);
+
+			const client = new SandboxClient(makeConfig());
+			const result = await client.resume("sb-1");
+
+			expect(result.status).toBe(SandboxStatus.Pending);
+			expect(result.resumedFromPool).toBe(false);
 		});
 
 		it("pause throws SandboxError on 409", async () => {

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -59,6 +59,7 @@ describe("parseSandboxInfo", () => {
 				image: "python:3.10",
 				poolName: "gpu-pool",
 				createdAt: "2025-01-01T00:00:00Z",
+				resumedFromPool: true,
 			},
 			"my-ns",
 		);
@@ -66,6 +67,7 @@ describe("parseSandboxInfo", () => {
 		expect(info.image).toBe("python:3.10");
 		expect(info.pool).toBe("gpu-pool");
 		expect(info.createdAt).toBe("2025-01-01T00:00:00Z");
+		expect(info.resumedFromPool).toBe(true);
 	});
 
 	it("handles alternative field names (phase, pool, created_at, sandboxName)", () => {

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -535,6 +535,9 @@ describe("Sandbox", () => {
 				return url.includes("/exec");
 			});
 			expect(execCalls.length).toBeGreaterThanOrEqual(2);
+			const retryBody = JSON.parse(execCalls[1][1]?.body as string);
+			expect(retryBody.session_id).toBeUndefined();
+			expect(retryBody.reset_session).toBe(true);
 		});
 
 		it("waitUntilReady_warm_kernel_no_extra_latency", async () => {

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -441,6 +441,20 @@ describe("Sandbox", () => {
 			expect(sbx.status).toBe(SandboxStatus.Running);
 		});
 
+		it("resume preserves backend status", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockResolvedValueOnce(mockResponse({})); // pause
+			mockFetch.mockResolvedValueOnce(
+				mockResponse({ name: "sb-1", phase: "Pending", resumedFromPool: false }),
+			);
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			await sbx.pause();
+			await sbx.resume();
+			expect(sbx.status).toBe(SandboxStatus.Pending);
+		});
+
 		it("pause on killed sandbox throws", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
@@ -559,6 +573,58 @@ describe("Sandbox", () => {
 				return url.includes("/exec");
 			});
 			expect(execCalls.length).toBe(1);
+		});
+
+		it("waitUntilReady_skips_warmup_once_after_pool_resume", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockResolvedValueOnce(mockResponse({})); // pause
+			mockFetch.mockResolvedValueOnce(
+				mockResponse({ name: "sb-1", phase: "Running", resumedFromPool: true }),
+			);
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockImplementationOnce(async (_url, init) =>
+				probeRespond((init as RequestInit).body as string),
+			);
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			await sbx.pause();
+			await sbx.resume();
+			await sbx.waitUntilReady(5);
+
+			let execCalls = mockFetch.mock.calls.filter((c) => {
+				const url = c[0] as string;
+				return url.includes("/exec");
+			});
+			expect(execCalls).toHaveLength(0);
+
+			await sbx.waitUntilReady(5);
+			execCalls = mockFetch.mock.calls.filter((c) => {
+				const url = c[0] as string;
+				return url.includes("/exec");
+			});
+			expect(execCalls).toHaveLength(1);
+		});
+
+		it("waitUntilReady_does_not_skip_warmup_for_fromPool_claim", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(
+				mockResponse({ name: "sb-1", status: "Running", resumedFromPool: true }),
+			);
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockImplementationOnce(async (_url, init) =>
+				probeRespond((init as RequestInit).body as string),
+			);
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			await sbx.waitUntilReady(5);
+
+			const execCalls = mockFetch.mock.calls.filter((c) => {
+				const url = c[0] as string;
+				return url.includes("/exec");
+			});
+			expect(execCalls).toHaveLength(1);
 		});
 
 		it("waitUntilReady_warmup_timeout_does_not_throw", async () => {


### PR DESCRIPTION
## Summary
- Mirror Python SDK PR #26 (https://github.com/prokube/prokube-sdk/pull/26) by parsing resume responses instead of discarding them.
- Carry the backend `resumedFromPool` hint into sandbox state and skip the next warmup probe exactly once after `waitUntilReady()` confirms the resumed sandbox is Running.
- Preserve the normal `Sandbox.fromPool` claim hot path: claiming from a pool does not set the one-shot skip flag, and legacy empty resume responses still behave as Running/non-pool resumes.
- Retain the stale warmup-session reset fix already present on this branch.
- Keep `SandboxClient.resume(name)` as `Promise<void>` (non-breaking public API). The parsed resume response is exposed through the new `SandboxClient.resumeInfo(name): Promise<SandboxInfo>` method; `Sandbox.resume()` uses `resumeInfo()` internally to receive the pool-resume hint.
- `markSessionInvalid()` delegates to `resetSession()` to keep reset behavior in one place.

## Testing
- `npm test -- tests/client.test.ts tests/sandbox.test.ts tests/models.test.ts`
- `npm run typecheck`
- `npx biome check src/sandbox/models.ts src/sandbox/client.ts src/sandbox/sandbox.ts tests/models.test.ts tests/client.test.ts tests/sandbox.test.ts`
- `npm run build`

## Notes
- Full `npm run lint` still fails on existing unrelated formatting/lint issues outside this change, including `worktrees/`, `.tmp-release-consumer`, smoke files, and pre-existing lint rules.