### PR TITLE
fix: report sandbox execution timeouts as failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,11 @@ interface CodeResult {
 }
 ```
 
+Execution timeouts are returned as failed results, not successful executions:
+`CodeResult.success` is `false`, and command results have a non-zero `exitCode`
+so `commandSuccess(result)` returns `false`. Timeout details are included in the
+error fields or `stderr` when provided by the backend.
+
 ### Errors
 
 ```

--- a/src/sandbox/models.ts
+++ b/src/sandbox/models.ts
@@ -180,14 +180,12 @@ export function parseCommandResult(data: Record<string, unknown>): CommandResult
 }
 
 function isTimeoutExecutionResponse(data: Record<string, unknown>): boolean {
-	const values = [
-		data.stderr,
-		data.error_name,
-		data.errorName,
-		data.error_value,
-		data.errorValue,
-		data.detail,
-	];
+	const errorNames = [data.error_name, data.errorName];
+	if (errorNames.some((value) => typeof value === "string" && /timeout/i.test(value))) {
+		return true;
+	}
+
+	const values = [data.stderr, data.error_value, data.errorValue, data.detail];
 
 	return values.some((value) => typeof value === "string" && /\btime(?:d)?\s*out\b/i.test(value));
 }

--- a/src/sandbox/models.ts
+++ b/src/sandbox/models.ts
@@ -161,8 +161,8 @@ export function parseCodeResult(data: Record<string, unknown>): CodeResult {
 		stderr: (data.stderr as string) ?? "",
 		success: data.success === true && !timedOut,
 		executionTimeMs: ((data.durationMs ?? data.execution_time_ms) as number) ?? 0,
-		errorName: data.error_name as string | undefined,
-		errorValue: data.error_value as string | undefined,
+		errorName: (data.errorName ?? data.error_name) as string | undefined,
+		errorValue: (data.errorValue ?? data.error_value) as string | undefined,
 		traceback: data.traceback as string[] | undefined,
 		sessionId: data.session_id as string | undefined,
 	};

--- a/src/sandbox/models.ts
+++ b/src/sandbox/models.ts
@@ -155,10 +155,11 @@ export function parseSandboxInfo(data: Record<string, unknown>, workspace: strin
 }
 
 export function parseCodeResult(data: Record<string, unknown>): CodeResult {
+	const timedOut = isTimeoutExecutionResponse(data);
 	return {
 		stdout: (data.stdout as string) ?? "",
 		stderr: (data.stderr as string) ?? "",
-		success: data.success === true,
+		success: data.success === true && !timedOut,
 		executionTimeMs: ((data.durationMs ?? data.execution_time_ms) as number) ?? 0,
 		errorName: data.error_name as string | undefined,
 		errorValue: data.error_value as string | undefined,
@@ -168,12 +169,27 @@ export function parseCodeResult(data: Record<string, unknown>): CodeResult {
 }
 
 export function parseCommandResult(data: Record<string, unknown>): CommandResult {
+	const timedOut = isTimeoutExecutionResponse(data);
+	const exitCode = ((data.exitCode ?? data.exit_code) as number | undefined) ?? -1;
 	return {
 		stdout: (data.stdout as string) ?? "",
 		stderr: (data.stderr as string) ?? "",
-		exitCode: ((data.exitCode ?? data.exit_code) as number) ?? -1,
+		exitCode: timedOut ? -1 : exitCode,
 		durationMs: ((data.durationMs ?? data.duration_ms) as number) ?? 0,
 	};
+}
+
+function isTimeoutExecutionResponse(data: Record<string, unknown>): boolean {
+	const values = [
+		data.stderr,
+		data.error_name,
+		data.errorName,
+		data.error_value,
+		data.errorValue,
+		data.detail,
+	];
+
+	return values.some((value) => typeof value === "string" && /\btime(?:d)?\s*out\b/i.test(value));
 }
 
 export function parseFileInfo(data: Record<string, unknown>): FileInfo {
@@ -186,9 +202,7 @@ export function parseFileInfo(data: Record<string, unknown>): FileInfo {
 	};
 }
 
-export function parseBatchFileWriteResponse(
-	data: Record<string, unknown>,
-): BatchFileWriteResponse {
+export function parseBatchFileWriteResponse(data: Record<string, unknown>): BatchFileWriteResponse {
 	if (data.results !== undefined && !Array.isArray(data.results)) {
 		throw new Error("Invalid API response: batch results must be an array");
 	}

--- a/src/sandbox/models.ts
+++ b/src/sandbox/models.ts
@@ -185,9 +185,22 @@ function isTimeoutExecutionResponse(data: Record<string, unknown>): boolean {
 		return true;
 	}
 
-	const values = [data.stderr, data.error_value, data.errorValue, data.detail];
+	const structuredValues = [data.error_value, data.errorValue, data.detail];
+	if (
+		structuredValues.some(
+			(value) => typeof value === "string" && /\btime(?:d)?\s*out\b/i.test(value),
+		)
+	) {
+		return true;
+	}
 
-	return values.some((value) => typeof value === "string" && /\btime(?:d)?\s*out\b/i.test(value));
+	return typeof data.stderr === "string" && isTimeoutStderr(data.stderr);
+}
+
+function isTimeoutStderr(value: string): boolean {
+	return (
+		/^\s*\[?timeout\b/i.test(value) || /\b(?:execution|command|code)\s+timed\s+out\b/i.test(value)
+	);
 }
 
 export function parseFileInfo(data: Record<string, unknown>): FileInfo {

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -188,6 +188,18 @@ describe("parseCommandResult", () => {
 		expect(result.exitCode).toBe(-1);
 		expect(commandSuccess(result)).toBe(false);
 	});
+
+	it("does not fail a successful command for ordinary stderr timeout text", () => {
+		const result = parseCommandResult({
+			stdout: "ok\n",
+			stderr: "warning: timeout option ignored\n",
+			exitCode: 0,
+			durationMs: 10,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(commandSuccess(result)).toBe(true);
+	});
 });
 
 describe("parseFileInfo", () => {

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -139,6 +139,20 @@ describe("parseCodeResult", () => {
 		expect(result.success).toBe(false);
 		expect(result.errorName).toBe("TimeoutError");
 	});
+
+	it("parses camelCase error fields", () => {
+		const result = parseCodeResult({
+			stdout: "",
+			stderr: "",
+			success: false,
+			durationMs: 300,
+			errorName: "TimeoutError",
+			errorValue: "Code execution timed out",
+		});
+
+		expect(result.errorName).toBe("TimeoutError");
+		expect(result.errorValue).toBe("Code execution timed out");
+	});
 });
 
 describe("parseCommandResult", () => {

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -115,6 +115,31 @@ describe("parseCodeResult", () => {
 		expect(result.errorValue).toBe("oops");
 		expect(result.traceback).toEqual(["line 1", "line 2"]);
 	});
+
+	it("maps timeout code result to failure even if backend reports success", () => {
+		const result = parseCodeResult({
+			stdout: "",
+			stderr: "Execution timed out after 5 seconds",
+			success: true,
+			durationMs: 5000,
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.stderr).toContain("timed out");
+	});
+
+	it("maps timeout error name to failed code result", () => {
+		const result = parseCodeResult({
+			stdout: "",
+			stderr: "",
+			success: true,
+			error_name: "TimeoutError",
+			error_value: "execution timed out",
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.errorName).toBe("TimeoutError");
+	});
 });
 
 describe("parseCommandResult", () => {
@@ -137,6 +162,18 @@ describe("parseCommandResult", () => {
 			duration_ms: 200,
 		});
 		expect(result.exitCode).toBe(1);
+		expect(commandSuccess(result)).toBe(false);
+	});
+
+	it("maps timeout command result to non-zero exit even if backend reports exit 0", () => {
+		const result = parseCommandResult({
+			stdout: "",
+			stderr: "[Timeout: no response after 15s]",
+			exitCode: 0,
+			durationMs: 15000,
+		});
+
+		expect(result.exitCode).toBe(-1);
 		expect(commandSuccess(result)).toBe(false);
 	});
 });

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -134,7 +134,6 @@ describe("parseCodeResult", () => {
 			stderr: "",
 			success: true,
 			error_name: "TimeoutError",
-			error_value: "execution timed out",
 		});
 
 		expect(result.success).toBe(false);
@@ -169,6 +168,19 @@ describe("parseCommandResult", () => {
 		const result = parseCommandResult({
 			stdout: "",
 			stderr: "[Timeout: no response after 15s]",
+			exitCode: 0,
+			durationMs: 15000,
+		});
+
+		expect(result.exitCode).toBe(-1);
+		expect(commandSuccess(result)).toBe(false);
+	});
+
+	it("maps timeout command error name to non-zero exit", () => {
+		const result = parseCommandResult({
+			stdout: "",
+			stderr: "",
+			errorName: "ExecutionTimeout",
 			exitCode: 0,
 			durationMs: 15000,
 		});


### PR DESCRIPTION
## Summary
- Normalize timeout-shaped sandbox execution responses so runCode returns success=false even if the backend response says success=true
- Normalize command timeout responses to exitCode=-1 so commandSuccess returns false
- Document timeout result behavior and add unit tests for code and command timeout response mapping

Closes #27

## Testing
- npm test
- npm run typecheck
- npx biome check src/sandbox/models.ts tests/models.test.ts README.md
- npm run build
- npm run check:dts
- npm run pack:release

## Notes
- Did not change Sandbox.fromPool or warm-pool claim behavior.
- Full npm run lint still reports pre-existing formatting/lint issues outside this change.