### PR TITLE
fix: ship prebuilt SDK package without build deps

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build SDK
-        run: npm run build
-
       - name: Validate release tag
         if: github.event_name == 'release'
         run: |
@@ -34,8 +31,8 @@ jobs:
             exit 1
           fi
 
-      - name: Pack release tarball
-        run: mkdir -p ./.artifacts && npm pack --pack-destination ./.artifacts
+      - name: Build, pack, and smoke test npm production install
+        run: npm run smoke:release:npm
 
       - name: Prepare tagged release asset
         if: github.event_name == 'release'

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 20.19.0
 
       - name: Install dependencies
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,11 @@
 			"name": "prokube",
 			"version": "2026.5.31",
 			"license": "MIT",
-			"dependencies": {
-				"@types/node": "^25.5.0",
-				"tsup": "^8.0.0",
-				"typescript": "^5.7.0"
-			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.0",
+				"@types/node": "^25.5.0",
+				"tsup": "^8.0.0",
+				"typescript": "^5.7.0",
 				"vitest": "^3.0.0"
 			},
 			"engines": {
@@ -192,6 +190,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -208,6 +207,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -224,6 +224,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -240,6 +241,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -256,6 +258,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -272,6 +275,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -288,6 +292,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -304,6 +309,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -320,6 +326,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -336,6 +343,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -352,6 +360,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -368,6 +377,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -384,6 +394,7 @@
 			"cpu": [
 				"mips64el"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -400,6 +411,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -416,6 +428,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -432,6 +445,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -448,6 +462,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -464,6 +479,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -480,6 +496,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -496,6 +513,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -512,6 +530,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -528,6 +547,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -544,6 +564,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -560,6 +581,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -576,6 +598,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -592,6 +615,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -605,6 +629,7 @@
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
 			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -615,6 +640,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -624,12 +650,14 @@
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
 			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.31",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
 			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
@@ -643,6 +671,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -656,6 +685,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -669,6 +699,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -682,6 +713,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -695,6 +727,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -708,6 +741,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -721,6 +755,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -734,6 +769,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -747,6 +783,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -760,6 +797,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -773,6 +811,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -786,6 +825,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -799,6 +839,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -812,6 +853,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -825,6 +867,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -838,6 +881,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -851,6 +895,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -864,6 +909,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -877,6 +923,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -890,6 +937,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -903,6 +951,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -916,6 +965,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -929,6 +979,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -942,6 +993,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -955,6 +1007,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -983,12 +1036,14 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "25.5.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
 			"integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.18.0"
@@ -1113,6 +1168,7 @@
 			"version": "8.16.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -1125,6 +1181,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
 			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/assertion-error": {
@@ -1141,6 +1198,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
 			"integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"load-tsconfig": "^0.2.3"
@@ -1156,6 +1214,7 @@
 			"version": "6.7.14",
 			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
 			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -1192,6 +1251,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
 			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"readdirp": "^4.0.1"
@@ -1207,6 +1267,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
 			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
@@ -1216,12 +1277,14 @@
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
 			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/consola": {
 			"version": "3.4.2",
 			"resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
 			"integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^14.18.0 || >=16.10.0"
@@ -1231,6 +1294,7 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -1265,6 +1329,7 @@
 			"version": "0.27.7",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
 			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -1326,6 +1391,7 @@
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
 			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.0.0"
@@ -1343,6 +1409,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
 			"integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"magic-string": "^0.30.17",
@@ -1354,6 +1421,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -1368,6 +1436,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
 			"integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -1384,6 +1453,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
 			"integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14"
@@ -1396,12 +1466,14 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/load-tsconfig": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
 			"integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -1418,6 +1490,7 @@
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
 			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
@@ -1427,6 +1500,7 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
 			"integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"acorn": "^8.16.0",
@@ -1439,12 +1513,14 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mz": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
 			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"any-promise": "^1.0.0",
@@ -1456,7 +1532,7 @@
 			"version": "3.3.11",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
 			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -1475,6 +1551,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -1484,6 +1561,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/pathval": {
@@ -1500,12 +1578,14 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -1518,6 +1598,7 @@
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
 			"integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
@@ -1527,6 +1608,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
 			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"confbox": "^0.1.8",
@@ -1538,7 +1620,7 @@
 			"version": "8.5.8",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
 			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1567,6 +1649,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
 			"integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1609,6 +1692,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
 			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14.18.0"
@@ -1622,6 +1706,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -1631,6 +1716,7 @@
 			"version": "4.60.1",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
 			"integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "1.0.8"
@@ -1682,6 +1768,7 @@
 			"version": "0.7.6",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
 			"integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">= 12"
@@ -1691,7 +1778,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -1728,6 +1815,7 @@
 			"version": "3.35.1",
 			"resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
 			"integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.2",
@@ -1750,6 +1838,7 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
 			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"any-promise": "^1.0.0"
@@ -1759,6 +1848,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
 			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"thenify": ">= 3.1.0 < 4"
@@ -1778,12 +1868,14 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
 			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.15",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
 			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fdir": "^6.5.0",
@@ -1830,6 +1922,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
 			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"tree-kill": "cli.js"
@@ -1839,12 +1932,14 @@
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
 			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/tsup": {
 			"version": "8.5.1",
 			"resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
 			"integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bundle-require": "^5.1.0",
@@ -1897,6 +1992,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
@@ -1910,12 +2006,14 @@
 			"version": "1.6.3",
 			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
 			"integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/undici-types": {
 			"version": "7.18.2",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
 			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/vite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prokube",
-	"version": "2026.5.31",
+	"version": "2026.6.30",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prokube",
-			"version": "2026.5.31",
+			"version": "2026.6.30",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prokube",
-	"version": "2026.5.31",
+	"version": "2026.6.30",
 	"description": "TypeScript SDK for the prokube.ai sandbox platform",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -18,14 +18,12 @@
 			}
 		}
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"scripts": {
 		"build": "node ./scripts/build.mjs",
-		"prepare": "node ./scripts/build.mjs",
 		"check:dts": "node ./scripts/check-dts.mjs",
 		"pack:release": "npm run build && npm pack --pack-destination ./.artifacts",
+		"smoke:release:npm": "node ./scripts/smoke-release-npm.mjs",
 		"smoke:release": "node ./scripts/smoke-release.mjs",
 		"test": "vitest run",
 		"test:watch": "vitest",
@@ -34,25 +32,16 @@
 		"format": "biome format --write .",
 		"typecheck": "tsc --noEmit"
 	},
-	"keywords": [
-		"prokube",
-		"sandbox",
-		"ai",
-		"ml",
-		"kubernetes",
-		"sdk"
-	],
+	"keywords": ["prokube", "sandbox", "ai", "ml", "kubernetes", "sdk"],
 	"license": "MIT",
 	"engines": {
 		"node": ">=20.19.0"
 	},
-	"dependencies": {
-		"@types/node": "^25.5.0",
-		"tsup": "^8.0.0",
-		"typescript": "^5.7.0"
-	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.0",
+		"@types/node": "^25.5.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.7.0",
 		"vitest": "^3.0.0"
 	}
 }

--- a/scripts/smoke-release-npm.mjs
+++ b/scripts/smoke-release-npm.mjs
@@ -1,0 +1,124 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const artifactsDir = path.join(repoRoot, ".artifacts");
+const packageJson = JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+const tarballPath = path.join(artifactsDir, `${packageJson.name}-${packageJson.version}.tgz`);
+
+mkdirSync(artifactsDir, { recursive: true });
+
+execFileSync("npm", ["run", "pack:release"], {
+	cwd: repoRoot,
+	stdio: "inherit",
+});
+
+if (!existsSync(tarballPath)) {
+	throw new Error(`Expected release tarball at ${tarballPath}`);
+}
+
+const consumerDir = mkdtempSync(path.join(os.tmpdir(), "prokube-sdk-consumer-"));
+
+writeFileSync(
+	path.join(consumerDir, "package.json"),
+	`${JSON.stringify(
+		{
+			name: "prokube-sdk-release-consumer-smoke",
+			private: true,
+			type: "module",
+			dependencies: {
+				prokube: `file:${tarballPath}`,
+			},
+		},
+		null,
+		2,
+	)}\n`,
+);
+
+writeFileSync(
+	path.join(consumerDir, "index.mjs"),
+	`import { Config, Sandbox, commandSuccess } from "prokube";
+
+const config = new Config({
+  apiUrl: "https://example.invalid/pkui",
+  workspace: "smoke-test",
+  apiKey: "test-key",
+});
+
+if (!config.useApiKey) {
+  throw new Error("Expected Config.useApiKey to be true");
+}
+
+if (typeof Sandbox.fromPool !== "function") {
+  throw new Error("Expected Sandbox.fromPool to be available");
+}
+
+if (!commandSuccess({ stdout: "", stderr: "", exitCode: 0, durationMs: 1 })) {
+  throw new Error("Expected commandSuccess helper to return true");
+}
+`,
+);
+
+writeFileSync(
+	path.join(consumerDir, "index.cjs"),
+	`const { Config, Sandbox, commandSuccess } = require("prokube");
+
+const config = new Config({
+  apiUrl: "https://example.invalid/pkui",
+  workspace: "smoke-test",
+  apiKey: "test-key",
+});
+
+if (!config.useApiKey) {
+  throw new Error("Expected Config.useApiKey to be true");
+}
+
+if (typeof Sandbox.fromPool !== "function") {
+  throw new Error("Expected Sandbox.fromPool to be available");
+}
+
+if (!commandSuccess({ stdout: "", stderr: "", exitCode: 0, durationMs: 1 })) {
+  throw new Error("Expected commandSuccess helper to return true");
+}
+`,
+);
+
+execFileSync("npm", ["install", "--omit=dev"], {
+	cwd: consumerDir,
+	stdio: "inherit",
+});
+
+execFileSync("node", ["index.mjs"], { cwd: consumerDir, stdio: "inherit" });
+execFileSync("node", ["index.cjs"], { cwd: consumerDir, stdio: "inherit" });
+
+const installedPackageDir = path.join(consumerDir, "node_modules", "prokube");
+const installedPackageJson = JSON.parse(
+	readFileSync(path.join(installedPackageDir, "package.json"), "utf8"),
+);
+
+if (installedPackageJson.scripts?.prepare) {
+	throw new Error("Release package must not include a consumer-install prepare script");
+}
+
+for (const distFile of ["index.js", "index.cjs", "index.d.ts", "index.d.cts"]) {
+	if (!existsSync(path.join(installedPackageDir, "dist", distFile))) {
+		throw new Error(`Release package is missing dist/${distFile}`);
+	}
+}
+
+const forbiddenRuntimePackages = [["tsup"], ["typescript"], ["@types", "node"], ["esbuild"]];
+
+for (const packagePath of forbiddenRuntimePackages) {
+	const installedPath = path.join(consumerDir, "node_modules", ...packagePath);
+	if (existsSync(installedPath)) {
+		throw new Error(
+			`Build-only package ${packagePath.join("/")} was installed as a runtime dependency`,
+		);
+	}
+}
+
+console.log(`npm production install smoke test passed in ${consumerDir}`);

--- a/scripts/smoke-release-npm.mjs
+++ b/scripts/smoke-release-npm.mjs
@@ -133,39 +133,24 @@ function dependencyTreeIncludesPackage(dependencies, dependencyName) {
 	return false;
 }
 
-function listRuntimeDependency(dependencyName) {
-	let output;
-
-	try {
-		output = execFileSync("npm", ["ls", dependencyName, "--all", "--omit=dev", "--json"], {
-			cwd: consumerDir,
-			encoding: "utf8",
-			stdio: ["ignore", "pipe", "pipe"],
-		});
-	} catch (error) {
-		if (!(error instanceof Error) || !("stdout" in error)) {
-			throw error;
-		}
-
-		output = error.stdout?.toString();
-		if (!output) {
-			throw new Error(
-				`Unable to inspect runtime dependency ${dependencyName}: npm ls returned no JSON`,
-			);
-		}
-	}
+function listRuntimeDependencies() {
+	const output = execFileSync("npm", ["ls", "--all", "--omit=dev", "--json"], {
+		cwd: consumerDir,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
 
 	try {
 		return JSON.parse(output);
 	} catch (error) {
-		throw new Error(`Unable to parse npm ls output for ${dependencyName}: ${error.message}`);
+		throw new Error(`Unable to parse npm ls runtime dependency output: ${error.message}`);
 	}
 }
 
-for (const dependencyName of forbiddenRuntimePackages) {
-	const dependencyTree = listRuntimeDependency(dependencyName);
+const runtimeDependencyTree = listRuntimeDependencies();
 
-	if (dependencyTreeIncludesPackage(dependencyTree.dependencies, dependencyName)) {
+for (const dependencyName of forbiddenRuntimePackages) {
+	if (dependencyTreeIncludesPackage(runtimeDependencyTree.dependencies, dependencyName)) {
 		throw new Error(`Build-only package ${dependencyName} was installed as a runtime dependency`);
 	}
 }

--- a/scripts/smoke-release-npm.mjs
+++ b/scripts/smoke-release-npm.mjs
@@ -8,7 +8,10 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
 const artifactsDir = path.join(repoRoot, ".artifacts");
 const packageJson = JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8"));
-const tarballPath = path.join(artifactsDir, `${packageJson.name}-${packageJson.version}.tgz`);
+const packageName = packageJson.name;
+const packageInstallPath = packageName.split("/");
+const packedName = packageName.replace(/^@/, "").replaceAll("/", "-");
+const tarballPath = path.join(artifactsDir, `${packedName}-${packageJson.version}.tgz`);
 
 mkdirSync(artifactsDir, { recursive: true });
 
@@ -31,7 +34,7 @@ writeFileSync(
 			private: true,
 			type: "module",
 			dependencies: {
-				prokube: `file:${tarballPath}`,
+				[packageName]: `file:${tarballPath}`,
 			},
 		},
 		null,
@@ -41,7 +44,7 @@ writeFileSync(
 
 writeFileSync(
 	path.join(consumerDir, "index.mjs"),
-	`import { Config, Sandbox, commandSuccess } from "prokube";
+	`import { Config, Sandbox, commandSuccess } from ${JSON.stringify(packageName)};
 
 const config = new Config({
   apiUrl: "https://example.invalid/pkui",
@@ -65,7 +68,7 @@ if (!commandSuccess({ stdout: "", stderr: "", exitCode: 0, durationMs: 1 })) {
 
 writeFileSync(
 	path.join(consumerDir, "index.cjs"),
-	`const { Config, Sandbox, commandSuccess } = require("prokube");
+	`const { Config, Sandbox, commandSuccess } = require(${JSON.stringify(packageName)});
 
 const config = new Config({
   apiUrl: "https://example.invalid/pkui",
@@ -95,7 +98,7 @@ execFileSync("npm", ["install", "--omit=dev"], {
 execFileSync("node", ["index.mjs"], { cwd: consumerDir, stdio: "inherit" });
 execFileSync("node", ["index.cjs"], { cwd: consumerDir, stdio: "inherit" });
 
-const installedPackageDir = path.join(consumerDir, "node_modules", "prokube");
+const installedPackageDir = path.join(consumerDir, "node_modules", ...packageInstallPath);
 const installedPackageJson = JSON.parse(
 	readFileSync(path.join(installedPackageDir, "package.json"), "utf8"),
 );
@@ -113,8 +116,12 @@ for (const distFile of ["index.js", "index.cjs", "index.d.ts", "index.d.cts"]) {
 const forbiddenRuntimePackages = [["tsup"], ["typescript"], ["@types", "node"], ["esbuild"]];
 
 for (const packagePath of forbiddenRuntimePackages) {
-	const installedPath = path.join(consumerDir, "node_modules", ...packagePath);
-	if (existsSync(installedPath)) {
+	const installedPaths = [
+		path.join(consumerDir, "node_modules", ...packagePath),
+		path.join(installedPackageDir, "node_modules", ...packagePath),
+	];
+
+	if (installedPaths.some((installedPath) => existsSync(installedPath))) {
 		throw new Error(
 			`Build-only package ${packagePath.join("/")} was installed as a runtime dependency`,
 		);

--- a/scripts/smoke-release-npm.mjs
+++ b/scripts/smoke-release-npm.mjs
@@ -115,17 +115,58 @@ for (const distFile of ["index.js", "index.cjs", "index.d.ts", "index.d.cts"]) {
 
 const forbiddenRuntimePackages = ["tsup", "typescript", "@types/node", "esbuild"];
 
-for (const packageName of forbiddenRuntimePackages) {
+function dependencyTreeIncludesPackage(dependencies, dependencyName) {
+	if (!dependencies) {
+		return false;
+	}
+
+	for (const [installedName, dependency] of Object.entries(dependencies)) {
+		if (installedName === dependencyName) {
+			return true;
+		}
+
+		if (dependencyTreeIncludesPackage(dependency.dependencies, dependencyName)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function listRuntimeDependency(dependencyName) {
+	let output;
+
 	try {
-		execFileSync("npm", ["ls", packageName, "--all", "--omit=dev", "--json"], {
+		output = execFileSync("npm", ["ls", dependencyName, "--all", "--omit=dev", "--json"], {
 			cwd: consumerDir,
+			encoding: "utf8",
 			stdio: ["ignore", "pipe", "pipe"],
 		});
-		throw new Error(`Build-only package ${packageName} was installed as a runtime dependency`);
 	} catch (error) {
-		if (error instanceof Error && error.message.startsWith("Build-only package")) {
+		if (!(error instanceof Error) || !("stdout" in error)) {
 			throw error;
 		}
+
+		output = error.stdout?.toString();
+		if (!output) {
+			throw new Error(
+				`Unable to inspect runtime dependency ${dependencyName}: npm ls returned no JSON`,
+			);
+		}
+	}
+
+	try {
+		return JSON.parse(output);
+	} catch (error) {
+		throw new Error(`Unable to parse npm ls output for ${dependencyName}: ${error.message}`);
+	}
+}
+
+for (const dependencyName of forbiddenRuntimePackages) {
+	const dependencyTree = listRuntimeDependency(dependencyName);
+
+	if (dependencyTreeIncludesPackage(dependencyTree.dependencies, dependencyName)) {
+		throw new Error(`Build-only package ${dependencyName} was installed as a runtime dependency`);
 	}
 }
 

--- a/scripts/smoke-release-npm.mjs
+++ b/scripts/smoke-release-npm.mjs
@@ -113,18 +113,19 @@ for (const distFile of ["index.js", "index.cjs", "index.d.ts", "index.d.cts"]) {
 	}
 }
 
-const forbiddenRuntimePackages = [["tsup"], ["typescript"], ["@types", "node"], ["esbuild"]];
+const forbiddenRuntimePackages = ["tsup", "typescript", "@types/node", "esbuild"];
 
-for (const packagePath of forbiddenRuntimePackages) {
-	const installedPaths = [
-		path.join(consumerDir, "node_modules", ...packagePath),
-		path.join(installedPackageDir, "node_modules", ...packagePath),
-	];
-
-	if (installedPaths.some((installedPath) => existsSync(installedPath))) {
-		throw new Error(
-			`Build-only package ${packagePath.join("/")} was installed as a runtime dependency`,
-		);
+for (const packageName of forbiddenRuntimePackages) {
+	try {
+		execFileSync("npm", ["ls", packageName, "--all", "--omit=dev", "--json"], {
+			cwd: consumerDir,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		throw new Error(`Build-only package ${packageName} was installed as a runtime dependency`);
+	} catch (error) {
+		if (error instanceof Error && error.message.startsWith("Build-only package")) {
+			throw error;
+		}
 	}
 }
 

--- a/scripts/smoke-release-npm.mjs
+++ b/scripts/smoke-release-npm.mjs
@@ -1,4 +1,4 @@
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -115,50 +115,20 @@ for (const distFile of ["index.js", "index.cjs", "index.d.ts", "index.d.cts"]) {
 
 const forbiddenRuntimePackages = ["tsup", "typescript", "@types/node", "esbuild"];
 
-function dependencyTreeIncludesPackage(dependencies, dependencyName) {
-	if (!dependencies) {
-		return false;
-	}
+const consumerLockfile = JSON.parse(
+	readFileSync(path.join(consumerDir, "package-lock.json"), "utf8"),
+);
 
-	for (const [installedName, dependency] of Object.entries(dependencies)) {
-		if (installedName === dependencyName) {
-			return true;
-		}
+function lockfileIncludesPackage(lockfile, dependencyName) {
+	const modulePath = `node_modules/${dependencyName}`;
 
-		if (dependencyTreeIncludesPackage(dependency.dependencies, dependencyName)) {
-			return true;
-		}
-	}
-
-	return false;
+	return Object.keys(lockfile.packages ?? {}).some(
+		(packagePath) => packagePath === modulePath || packagePath.endsWith(`/${modulePath}`),
+	);
 }
-
-function listRuntimeDependencies() {
-	const result = spawnSync("npm", ["ls", "--all", "--omit=dev", "--json"], {
-		cwd: consumerDir,
-		encoding: "utf8",
-		stdio: ["ignore", "pipe", "pipe"],
-	});
-
-	if (result.error) {
-		throw result.error;
-	}
-
-	if (!result.stdout) {
-		throw new Error("Unable to inspect runtime dependencies: npm ls returned no JSON");
-	}
-
-	try {
-		return JSON.parse(result.stdout);
-	} catch (error) {
-		throw new Error(`Unable to parse npm ls runtime dependency output: ${error.message}`);
-	}
-}
-
-const runtimeDependencyTree = listRuntimeDependencies();
 
 for (const dependencyName of forbiddenRuntimePackages) {
-	if (dependencyTreeIncludesPackage(runtimeDependencyTree.dependencies, dependencyName)) {
+	if (lockfileIncludesPackage(consumerLockfile, dependencyName)) {
 		throw new Error(`Build-only package ${dependencyName} was installed as a runtime dependency`);
 	}
 }

--- a/scripts/smoke-release-npm.mjs
+++ b/scripts/smoke-release-npm.mjs
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -134,14 +134,22 @@ function dependencyTreeIncludesPackage(dependencies, dependencyName) {
 }
 
 function listRuntimeDependencies() {
-	const output = execFileSync("npm", ["ls", "--all", "--omit=dev", "--json"], {
+	const result = spawnSync("npm", ["ls", "--all", "--omit=dev", "--json"], {
 		cwd: consumerDir,
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "pipe"],
 	});
 
+	if (result.error) {
+		throw result.error;
+	}
+
+	if (!result.stdout) {
+		throw new Error("Unable to inspect runtime dependencies: npm ls returned no JSON");
+	}
+
 	try {
-		return JSON.parse(output);
+		return JSON.parse(result.stdout);
 	} catch (error) {
 		throw new Error(`Unable to parse npm ls runtime dependency output: ${error.message}`);
 	}

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -55,9 +55,16 @@ export class SandboxClient {
 
 	// ---- Sandbox lifecycle ----
 
-	async claimFromPool(pool: string, volumeSize?: string): Promise<SandboxInfo> {
+	async claimFromPool(
+		pool: string,
+		volumeSize?: string,
+		autoIdleTimeoutSeconds?: number,
+	): Promise<SandboxInfo> {
 		const body: Record<string, unknown> = { poolName: pool };
-		if (volumeSize) body.volumeSize = volumeSize;
+		if (volumeSize !== undefined) body.volumeSize = volumeSize;
+		if (autoIdleTimeoutSeconds !== undefined) {
+			body.autoIdleTimeoutSeconds = autoIdleTimeoutSeconds;
+		}
 
 		try {
 			const data = (await this.http.post(`${this.sandboxesPath()}/claim`, body)) as Record<
@@ -74,8 +81,17 @@ export class SandboxClient {
 	}
 
 	async create(params: CreateSandboxRequest): Promise<SandboxInfo> {
-		const { image, name, volumeSize, cpu, memory, allowInternetAccess, envVars, secretRefs } =
-			params;
+		const {
+			image,
+			name,
+			volumeSize,
+			cpu,
+			memory,
+			allowInternetAccess,
+			autoIdleTimeoutSeconds,
+			envVars,
+			secretRefs,
+		} = params;
 
 		// Use `!== undefined` for every optional field so that explicit
 		// falsy/empty values ("", "0") are forwarded to the backend (which
@@ -88,6 +104,9 @@ export class SandboxClient {
 		if (cpu !== undefined) body.cpu = cpu;
 		if (memory !== undefined) body.memory = memory;
 		if (allowInternetAccess !== undefined) body.allowInternetAccess = allowInternetAccess;
+		if (autoIdleTimeoutSeconds !== undefined) {
+			body.autoIdleTimeoutSeconds = autoIdleTimeoutSeconds;
+		}
 		if (envVars !== undefined) body.envVars = envVars;
 		if (secretRefs !== undefined) body.secretRefs = secretRefs;
 

--- a/src/sandbox/models.ts
+++ b/src/sandbox/models.ts
@@ -157,7 +157,9 @@ export function parseSandboxInfo(data: Record<string, unknown>, workspace: strin
 		image: data.image as string | undefined,
 		pool: (data.poolName ?? data.pool) as string | undefined,
 		createdAt: (data.createdAt ?? data.created_at) as string | undefined,
-		autoIdleTimeoutSeconds: data.autoIdleTimeoutSeconds as number | undefined,
+		autoIdleTimeoutSeconds: (data.autoIdleTimeoutSeconds ?? data.auto_idle_timeout_seconds) as
+			| number
+			| undefined,
 		resumedFromPool: data.resumedFromPool === true,
 	};
 }
@@ -294,7 +296,9 @@ export function parsePoolInfo(data: Record<string, unknown>, workspace: string):
 		image: data.image as string | undefined,
 		cpu: data.cpu as string | undefined,
 		memory: data.memory as string | undefined,
-		autoIdleTimeoutSeconds: data.autoIdleTimeoutSeconds as number | undefined,
+		autoIdleTimeoutSeconds: (data.autoIdleTimeoutSeconds ?? data.auto_idle_timeout_seconds) as
+			| number
+			| undefined,
 	};
 }
 

--- a/src/sandbox/models.ts
+++ b/src/sandbox/models.ts
@@ -15,6 +15,7 @@ export interface SandboxInfo {
 	image?: string;
 	pool?: string;
 	createdAt?: string;
+	autoIdleTimeoutSeconds?: number;
 	resumedFromPool?: boolean;
 }
 
@@ -72,6 +73,7 @@ export interface PoolInfo {
 	image?: string;
 	cpu?: string;
 	memory?: string;
+	autoIdleTimeoutSeconds?: number;
 }
 
 export interface EnvVar {
@@ -91,6 +93,7 @@ export interface CreatePoolRequest {
 	cpu?: string;
 	memory?: string;
 	allowInternetAccess?: boolean;
+	autoIdleTimeoutSeconds?: number;
 	envVars?: EnvVar[];
 	secretRefs?: string[];
 }
@@ -102,6 +105,7 @@ export interface CreateSandboxRequest {
 	cpu?: string;
 	memory?: string;
 	allowInternetAccess?: boolean;
+	autoIdleTimeoutSeconds?: number;
 	envVars?: EnvVar[];
 	secretRefs?: string[];
 }
@@ -111,6 +115,7 @@ export interface CreateSandboxRequest {
 export interface ClaimRequest {
 	poolName: string;
 	volumeSize?: string;
+	autoIdleTimeoutSeconds?: number;
 }
 
 export interface ExecRequest {
@@ -152,6 +157,7 @@ export function parseSandboxInfo(data: Record<string, unknown>, workspace: strin
 		image: data.image as string | undefined,
 		pool: (data.poolName ?? data.pool) as string | undefined,
 		createdAt: (data.createdAt ?? data.created_at) as string | undefined,
+		autoIdleTimeoutSeconds: data.autoIdleTimeoutSeconds as number | undefined,
 		resumedFromPool: data.resumedFromPool === true,
 	};
 }
@@ -288,6 +294,7 @@ export function parsePoolInfo(data: Record<string, unknown>, workspace: string):
 		image: data.image as string | undefined,
 		cpu: data.cpu as string | undefined,
 		memory: data.memory as string | undefined,
+		autoIdleTimeoutSeconds: data.autoIdleTimeoutSeconds as number | undefined,
 	};
 }
 

--- a/src/sandbox/pool-client.ts
+++ b/src/sandbox/pool-client.ts
@@ -28,7 +28,17 @@ export class PoolClient {
 	// ---- Pool operations ----
 
 	async create(params: CreatePoolRequest): Promise<PoolInfo> {
-		const { name, image, poolSize, cpu, memory, allowInternetAccess, envVars, secretRefs } = params;
+		const {
+			name,
+			image,
+			poolSize,
+			cpu,
+			memory,
+			allowInternetAccess,
+			autoIdleTimeoutSeconds,
+			envVars,
+			secretRefs,
+		} = params;
 
 		// Use `!== undefined` for every optional field so that explicit
 		// falsy/empty values ("", "0") are forwarded to the backend (which
@@ -39,6 +49,9 @@ export class PoolClient {
 		if (cpu !== undefined) body.cpu = cpu;
 		if (memory !== undefined) body.memory = memory;
 		if (allowInternetAccess !== undefined) body.allowInternetAccess = allowInternetAccess;
+		if (autoIdleTimeoutSeconds !== undefined) {
+			body.autoIdleTimeoutSeconds = autoIdleTimeoutSeconds;
+		}
 		if (envVars !== undefined) body.envVars = envVars;
 		if (secretRefs !== undefined) body.secretRefs = secretRefs;
 

--- a/src/sandbox/pool.ts
+++ b/src/sandbox/pool.ts
@@ -68,7 +68,13 @@ export class SandboxPool {
 				envVars: options.envVars,
 				secretRefs: options.secretRefs,
 			});
-			return new SandboxPool(info, client);
+			return new SandboxPool(
+				{
+					...info,
+					autoIdleTimeoutSeconds: info.autoIdleTimeoutSeconds ?? options.autoIdleTimeoutSeconds,
+				},
+				client,
+			);
 		} catch (e) {
 			client.close();
 			throw e;
@@ -161,6 +167,8 @@ export class SandboxPool {
 		if (info.image) this._image = info.image;
 		if (info.cpu) this._cpu = info.cpu;
 		if (info.memory) this._memory = info.memory;
-		this._autoIdleTimeoutSeconds = info.autoIdleTimeoutSeconds;
+		if (info.autoIdleTimeoutSeconds !== undefined) {
+			this._autoIdleTimeoutSeconds = info.autoIdleTimeoutSeconds;
+		}
 	}
 }

--- a/src/sandbox/pool.ts
+++ b/src/sandbox/pool.ts
@@ -17,6 +17,8 @@ export interface CreatePoolOptions extends ConfigOptions {
 	resources?: ResourceRequests;
 	/** If set, whether pool members may reach the public internet. */
 	allowInternetAccess?: boolean;
+	/** Default auto-idle timeout in seconds for sandboxes claimed from this pool. */
+	autoIdleTimeoutSeconds?: number;
 	/** Environment variables to inject into each pool member. */
 	envVars?: EnvVar[];
 	/** Names of Kubernetes secrets to mount/reference in each pool member. */
@@ -32,6 +34,7 @@ export class SandboxPool {
 	private _image: string | undefined;
 	private _cpu: string | undefined;
 	private _memory: string | undefined;
+	private _autoIdleTimeoutSeconds: number | undefined;
 
 	private constructor(info: PoolInfo, client: PoolClient) {
 		this._client = client;
@@ -42,6 +45,7 @@ export class SandboxPool {
 		this._image = info.image;
 		this._cpu = info.cpu;
 		this._memory = info.memory;
+		this._autoIdleTimeoutSeconds = info.autoIdleTimeoutSeconds;
 	}
 
 	// ---- Factory methods ----
@@ -60,6 +64,7 @@ export class SandboxPool {
 				cpu: options.resources?.cpu,
 				memory: options.resources?.memory,
 				allowInternetAccess: options.allowInternetAccess,
+				autoIdleTimeoutSeconds: options.autoIdleTimeoutSeconds,
 				envVars: options.envVars,
 				secretRefs: options.secretRefs,
 			});
@@ -129,6 +134,10 @@ export class SandboxPool {
 		return this._memory;
 	}
 
+	get autoIdleTimeoutSeconds(): number | undefined {
+		return this._autoIdleTimeoutSeconds;
+	}
+
 	// ---- Operations ----
 
 	/**
@@ -152,5 +161,6 @@ export class SandboxPool {
 		if (info.image) this._image = info.image;
 		if (info.cpu) this._cpu = info.cpu;
 		if (info.memory) this._memory = info.memory;
+		this._autoIdleTimeoutSeconds = info.autoIdleTimeoutSeconds;
 	}
 }

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { Config, type ConfigOptions } from "../common/config.js";
-import { SandboxError, SandboxTimeoutError } from "../common/errors.js";
+import { ProKubeError, SandboxError, SandboxTimeoutError } from "../common/errors.js";
 import { SandboxClient } from "./client.js";
 import { CodeRunner } from "./code.js";
 import { CommandRunner } from "./commands.js";
@@ -304,7 +304,8 @@ export class Sandbox {
 	 * can return `success=true` with empty stdout.
 	 *
 	 * Bounded by `deadline`. Never throws on deadline exceeded — logs a
-	 * warning and returns. Propagates any error thrown by `runCode`.
+	 * warning and returns. Transient gateway timeouts during warmup are retried;
+	 * other errors from `runCode` still propagate.
 	 */
 	private async warmupKernel(deadline: number): Promise<void> {
 		this.checkNotKilled();
@@ -335,7 +336,19 @@ export class Sandbox {
 			// a separate concern (HTTP-layer fetch timeout). floor() at
 			// least guarantees probeTimeoutSec * 1000 <= remainingMs.
 			const probeTimeoutSec = Math.min(maxProbeTimeoutSec, Math.floor(remainingMs / 1000));
-			const result = await this.runCode(probeCode, "python", probeTimeoutSec);
+			let result: CodeResult;
+			try {
+				result = await this.runCode(probeCode, "python", probeTimeoutSec);
+			} catch (error) {
+				if (!(error instanceof ProKubeError) || error.statusCode !== 504) {
+					throw error;
+				}
+				this._code.markSessionInvalid();
+				const postErrorRemainingMs = deadline - Date.now();
+				if (postErrorRemainingMs <= 0) break;
+				await sleep(Math.min(probeIntervalMs, postErrorRemainingMs));
+				continue;
+			}
 			if (result.stdout.trim() === marker) return;
 			this._code.markSessionInvalid();
 

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -9,6 +9,8 @@ import { type CodeResult, type EnvVar, type ResourceRequests, SandboxStatus } fr
 
 export interface SandboxOptions extends ConfigOptions {
 	volumeSize?: string;
+	/** Per-claim auto-idle override in seconds. Omit to inherit the warm-pool/platform default. */
+	autoIdleTimeoutSeconds?: number;
 }
 
 /**
@@ -22,6 +24,8 @@ export interface SandboxCreateOptions extends SandboxOptions {
 	resources?: ResourceRequests;
 	/** If set, whether the sandbox may reach the public internet. */
 	allowInternetAccess?: boolean;
+	/** Per-sandbox auto-idle override in seconds. Omit to inherit the platform default. */
+	autoIdleTimeoutSeconds?: number;
 	/** Environment variables to inject into the sandbox. */
 	envVars?: EnvVar[];
 	/** Names of Kubernetes secrets to mount/reference in the sandbox. */
@@ -38,6 +42,7 @@ export class Sandbox {
 	private _status: SandboxStatus;
 	private _image: string | undefined;
 	private _pool: string | undefined;
+	private _autoIdleTimeoutSeconds: number | undefined;
 	private _killed = false;
 	private _skipNextWarmup = false;
 
@@ -51,6 +56,7 @@ export class Sandbox {
 		timeout: number,
 		image?: string,
 		pool?: string,
+		autoIdleTimeoutSeconds?: number,
 	) {
 		this._name = name;
 		this._workspace = workspace;
@@ -59,6 +65,7 @@ export class Sandbox {
 		this._timeout = timeout;
 		this._image = image;
 		this._pool = pool;
+		this._autoIdleTimeoutSeconds = autoIdleTimeoutSeconds;
 		this._code = new CodeRunner(client, name);
 		this._commands = new CommandRunner(client, name, timeout);
 		this._files = new FileManager(client, name);
@@ -74,7 +81,11 @@ export class Sandbox {
 		const config = new Config(options);
 		const client = new SandboxClient(config);
 		try {
-			const info = await client.claimFromPool(pool, options.volumeSize);
+			const info = await client.claimFromPool(
+				pool,
+				options.volumeSize,
+				options.autoIdleTimeoutSeconds,
+			);
 			return new Sandbox(
 				info.name,
 				config.workspace,
@@ -83,6 +94,7 @@ export class Sandbox {
 				config.timeout,
 				info.image,
 				pool,
+				info.autoIdleTimeoutSeconds,
 			);
 		} catch (e) {
 			client.close();
@@ -106,10 +118,20 @@ export class Sandbox {
 				cpu: options.resources?.cpu,
 				memory: options.resources?.memory,
 				allowInternetAccess: options.allowInternetAccess,
+				autoIdleTimeoutSeconds: options.autoIdleTimeoutSeconds,
 				envVars: options.envVars,
 				secretRefs: options.secretRefs,
 			});
-			return new Sandbox(info.name, config.workspace, client, info.status, config.timeout, image);
+			return new Sandbox(
+				info.name,
+				config.workspace,
+				client,
+				info.status,
+				config.timeout,
+				image,
+				info.pool,
+				info.autoIdleTimeoutSeconds,
+			);
 		} catch (e) {
 			client.close();
 			throw e;
@@ -132,6 +154,7 @@ export class Sandbox {
 				config.timeout,
 				info.image,
 				info.pool,
+				info.autoIdleTimeoutSeconds,
 			);
 		} catch (e) {
 			client.close();
@@ -162,6 +185,7 @@ export class Sandbox {
 							config.timeout,
 							info.image,
 							info.pool,
+							info.autoIdleTimeoutSeconds,
 						),
 				);
 		} finally {
@@ -204,6 +228,10 @@ export class Sandbox {
 		return this._code.getSessionId();
 	}
 
+	get autoIdleTimeoutSeconds(): number | undefined {
+		return this._autoIdleTimeoutSeconds;
+	}
+
 	// ---- Code execution ----
 
 	async runCode(code: string, language = "python", timeout?: number): Promise<CodeResult> {
@@ -230,6 +258,7 @@ export class Sandbox {
 		this._status = info.status;
 		if (info.image) this._image = info.image;
 		if (info.pool) this._pool = info.pool;
+		this._autoIdleTimeoutSeconds = info.autoIdleTimeoutSeconds;
 		this._skipNextWarmup = info.resumedFromPool === true;
 		this._code.markSessionInvalid();
 	}
@@ -332,6 +361,7 @@ export class Sandbox {
 		this._status = info.status;
 		if (info.image) this._image = info.image;
 		if (info.pool) this._pool = info.pool;
+		this._autoIdleTimeoutSeconds = info.autoIdleTimeoutSeconds;
 	}
 
 	// ---- Cleanup helper ----

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -94,7 +94,7 @@ export class Sandbox {
 				config.timeout,
 				info.image,
 				pool,
-				info.autoIdleTimeoutSeconds,
+				info.autoIdleTimeoutSeconds ?? options.autoIdleTimeoutSeconds,
 			);
 		} catch (e) {
 			client.close();
@@ -130,7 +130,7 @@ export class Sandbox {
 				config.timeout,
 				image,
 				info.pool,
-				info.autoIdleTimeoutSeconds,
+				info.autoIdleTimeoutSeconds ?? options.autoIdleTimeoutSeconds,
 			);
 		} catch (e) {
 			client.close();
@@ -258,7 +258,9 @@ export class Sandbox {
 		this._status = info.status;
 		if (info.image) this._image = info.image;
 		if (info.pool) this._pool = info.pool;
-		this._autoIdleTimeoutSeconds = info.autoIdleTimeoutSeconds;
+		if (info.autoIdleTimeoutSeconds !== undefined) {
+			this._autoIdleTimeoutSeconds = info.autoIdleTimeoutSeconds;
+		}
 		this._skipNextWarmup = info.resumedFromPool === true;
 		this._code.markSessionInvalid();
 	}
@@ -361,7 +363,9 @@ export class Sandbox {
 		this._status = info.status;
 		if (info.image) this._image = info.image;
 		if (info.pool) this._pool = info.pool;
-		this._autoIdleTimeoutSeconds = info.autoIdleTimeoutSeconds;
+		if (info.autoIdleTimeoutSeconds !== undefined) {
+			this._autoIdleTimeoutSeconds = info.autoIdleTimeoutSeconds;
+		}
 	}
 
 	// ---- Cleanup helper ----

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -78,6 +78,17 @@ describe("SandboxClient", () => {
 			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
 			expect(body.volumeSize).toBe("20Gi");
 		});
+
+		it("sends autoIdleTimeoutSeconds when provided", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ name: "sb-123", status: "Running" }));
+
+			const client = new SandboxClient(makeConfig());
+			await client.claimFromPool("pool", undefined, 900);
+
+			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			expect(body.autoIdleTimeoutSeconds).toBe(900);
+		});
 	});
 
 	describe("create", () => {
@@ -108,6 +119,7 @@ describe("SandboxClient", () => {
 			expect(body).not.toHaveProperty("cpu");
 			expect(body).not.toHaveProperty("memory");
 			expect(body).not.toHaveProperty("allowInternetAccess");
+			expect(body).not.toHaveProperty("autoIdleTimeoutSeconds");
 			expect(body).not.toHaveProperty("envVars");
 			expect(body).not.toHaveProperty("secretRefs");
 		});
@@ -133,6 +145,20 @@ describe("SandboxClient", () => {
 			expect(body.allowInternetAccess).toBe(true);
 			expect(body.envVars).toEqual([{ name: "FOO", value: "bar" }]);
 			expect(body.secretRefs).toEqual(["my-secret"]);
+		});
+
+		it("sends autoIdleTimeoutSeconds when provided", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ name: "my-sb", status: "Pending" }));
+
+			const client = new SandboxClient(makeConfig());
+			await client.create({
+				image: "python:3.10",
+				autoIdleTimeoutSeconds: 1800,
+			});
+
+			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			expect(body.autoIdleTimeoutSeconds).toBe(1800);
 		});
 
 		it("sends allowInternetAccess=false explicitly", async () => {

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -79,6 +79,7 @@ describe("parseSandboxInfo", () => {
 				phase: "Paused",
 				pool: "cpu-pool",
 				created_at: "2025-06-01",
+				auto_idle_timeout_seconds: 900,
 			},
 			"ns",
 		);
@@ -86,6 +87,7 @@ describe("parseSandboxInfo", () => {
 		expect(info.status).toBe(SandboxStatus.Paused);
 		expect(info.pool).toBe("cpu-pool");
 		expect(info.createdAt).toBe("2025-06-01");
+		expect(info.autoIdleTimeoutSeconds).toBe(900);
 	});
 });
 
@@ -284,12 +286,14 @@ describe("parsePoolInfo", () => {
 				poolName: "alt-pool",
 				poolSize: 10,
 				ready_replicas: 7,
+				auto_idle_timeout_seconds: 600,
 			},
 			"ns",
 		);
 		expect(info.name).toBe("alt-pool");
 		expect(info.replicas).toBe(10);
 		expect(info.readyReplicas).toBe(7);
+		expect(info.autoIdleTimeoutSeconds).toBe(600);
 	});
 
 	it("throws when name is missing", () => {

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -59,6 +59,7 @@ describe("parseSandboxInfo", () => {
 				image: "python:3.10",
 				poolName: "gpu-pool",
 				createdAt: "2025-01-01T00:00:00Z",
+				autoIdleTimeoutSeconds: 1800,
 				resumedFromPool: true,
 			},
 			"my-ns",
@@ -67,6 +68,7 @@ describe("parseSandboxInfo", () => {
 		expect(info.image).toBe("python:3.10");
 		expect(info.pool).toBe("gpu-pool");
 		expect(info.createdAt).toBe("2025-01-01T00:00:00Z");
+		expect(info.autoIdleTimeoutSeconds).toBe(1800);
 		expect(info.resumedFromPool).toBe(true);
 	});
 
@@ -262,6 +264,7 @@ describe("parsePoolInfo", () => {
 				image: "python:3.10",
 				cpu: "2",
 				memory: "4Gi",
+				autoIdleTimeoutSeconds: 1200,
 			},
 			"my-ns",
 		);
@@ -272,6 +275,7 @@ describe("parsePoolInfo", () => {
 		expect(info.image).toBe("python:3.10");
 		expect(info.cpu).toBe("2");
 		expect(info.memory).toBe("4Gi");
+		expect(info.autoIdleTimeoutSeconds).toBe(1200);
 	});
 
 	it("handles alternative field names (poolName, poolSize, ready_replicas)", () => {

--- a/tests/pool-client.test.ts
+++ b/tests/pool-client.test.ts
@@ -24,11 +24,11 @@ describe("PoolClient", () => {
 
 	beforeEach(() => {
 		process.env = { ...originalEnv };
-		delete process.env.PROKUBE_API_KEY;
-		delete process.env.PROKUBE_USER_ID;
-		delete process.env.PROKUBE_API_URL;
-		delete process.env.PROKUBE_WORKSPACE;
-		delete process.env.KF_USER;
+		process.env.PROKUBE_API_KEY = undefined;
+		process.env.PROKUBE_USER_ID = undefined;
+		process.env.PROKUBE_API_URL = undefined;
+		process.env.PROKUBE_WORKSPACE = undefined;
+		process.env.KF_USER = undefined;
 		vi.stubGlobal("fetch", vi.fn());
 	});
 
@@ -101,6 +101,7 @@ describe("PoolClient", () => {
 			expect(body.cpu).toBeUndefined();
 			expect(body.memory).toBeUndefined();
 			expect(body).not.toHaveProperty("allowInternetAccess");
+			expect(body).not.toHaveProperty("autoIdleTimeoutSeconds");
 			expect(body).not.toHaveProperty("envVars");
 			expect(body).not.toHaveProperty("secretRefs");
 		});
@@ -129,6 +130,22 @@ describe("PoolClient", () => {
 				{ name: "BAZ", value: "qux" },
 			]);
 			expect(body.secretRefs).toEqual(["my-secret", "other-secret"]);
+		});
+
+		it("sends autoIdleTimeoutSeconds when provided", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ name: "my-pool", replicas: 1, readyReplicas: 0 }));
+
+			const client = new PoolClient(makeConfig());
+			await client.create({
+				name: "my-pool",
+				image: "python:3.10",
+				poolSize: 1,
+				autoIdleTimeoutSeconds: 600,
+			});
+
+			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			expect(body.autoIdleTimeoutSeconds).toBe(600);
 		});
 
 		it("sends allowInternetAccess=false explicitly", async () => {

--- a/tests/pool.test.ts
+++ b/tests/pool.test.ts
@@ -71,6 +71,7 @@ describe("SandboxPool", () => {
 
 			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
 			expect(body).not.toHaveProperty("allowInternetAccess");
+			expect(body).not.toHaveProperty("autoIdleTimeoutSeconds");
 			expect(body).not.toHaveProperty("envVars");
 			expect(body).not.toHaveProperty("secretRefs");
 		});
@@ -96,6 +97,23 @@ describe("SandboxPool", () => {
 			expect(body.secretRefs).toEqual(["my-secret"]);
 			expect(body.cpu).toBe("2");
 			expect(body.memory).toBe("4Gi");
+		});
+
+		it("forwards autoIdleTimeoutSeconds to request body", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ ...poolData, autoIdleTimeoutSeconds: 1200 }));
+
+			const pool = await SandboxPool.create({
+				...defaultConfig,
+				name: "gpu-pool",
+				image: "python:3.10",
+				poolSize: 3,
+				autoIdleTimeoutSeconds: 1200,
+			});
+
+			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			expect(body.autoIdleTimeoutSeconds).toBe(1200);
+			expect(pool.autoIdleTimeoutSeconds).toBe(1200);
 		});
 	});
 

--- a/tests/pool.test.ts
+++ b/tests/pool.test.ts
@@ -208,5 +208,17 @@ describe("SandboxPool", () => {
 			expect(pool.cpu).toBe("4");
 			expect(pool.memory).toBe("8Gi");
 		});
+
+		it("preserves known autoIdleTimeoutSeconds when response omits it", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(mockResponse({ ...poolData, autoIdleTimeoutSeconds: 1200 }));
+			mockFetch.mockResolvedValueOnce(
+				mockResponse({ name: "gpu-pool", replicas: 5, readyReplicas: 5 }),
+			);
+
+			const pool = await SandboxPool.get("gpu-pool", defaultConfig);
+			await pool.refresh();
+			expect(pool.autoIdleTimeoutSeconds).toBe(1200);
+		});
 	});
 });

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -48,9 +48,10 @@ describe("Sandbox", () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", status: "Running" }));
 
-			await Sandbox.fromPool("pool", { ...defaultConfig, autoIdleTimeoutSeconds: 900 });
+			const sbx = await Sandbox.fromPool("pool", { ...defaultConfig, autoIdleTimeoutSeconds: 900 });
 			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
 			expect(body.autoIdleTimeoutSeconds).toBe(900);
+			expect(sbx.autoIdleTimeoutSeconds).toBe(900);
 		});
 	});
 
@@ -128,13 +129,14 @@ describe("Sandbox", () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", status: "Pending" }));
 
-			await Sandbox.create("python:3.10", {
+			const sbx = await Sandbox.create("python:3.10", {
 				...defaultConfig,
 				autoIdleTimeoutSeconds: 1800,
 			});
 
 			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
 			expect(body.autoIdleTimeoutSeconds).toBe(1800);
+			expect(sbx.autoIdleTimeoutSeconds).toBe(1800);
 		});
 	});
 
@@ -478,6 +480,18 @@ describe("Sandbox", () => {
 			expect(sbx.status).toBe(SandboxStatus.Pending);
 		});
 
+		it("resume preserves known autoIdleTimeoutSeconds when response omits it", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockResolvedValueOnce(mockResponse({})); // pause
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Running" }));
+
+			const sbx = await Sandbox.fromPool("pool", { ...defaultConfig, autoIdleTimeoutSeconds: 900 });
+			await sbx.pause();
+			await sbx.resume();
+			expect(sbx.autoIdleTimeoutSeconds).toBe(900);
+		});
+
 		it("pause on killed sandbox throws", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
@@ -486,6 +500,18 @@ describe("Sandbox", () => {
 			const sbx = await Sandbox.fromPool("pool", defaultConfig);
 			await sbx.kill();
 			await expect(sbx.pause()).rejects.toThrow(SandboxError);
+		});
+	});
+
+	describe("refresh", () => {
+		it("preserves known autoIdleTimeoutSeconds when response omits it", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+
+			const sbx = await Sandbox.fromPool("pool", { ...defaultConfig, autoIdleTimeoutSeconds: 900 });
+			await sbx.refresh();
+			expect(sbx.autoIdleTimeoutSeconds).toBe(900);
 		});
 	});
 

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -43,6 +43,15 @@ describe("Sandbox", () => {
 			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
 			expect(body.volumeSize).toBe("20Gi");
 		});
+
+		it("sends autoIdleTimeoutSeconds when provided", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", status: "Running" }));
+
+			await Sandbox.fromPool("pool", { ...defaultConfig, autoIdleTimeoutSeconds: 900 });
+			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			expect(body.autoIdleTimeoutSeconds).toBe(900);
+		});
 	});
 
 	describe("create", () => {
@@ -83,6 +92,7 @@ describe("Sandbox", () => {
 			expect(body).not.toHaveProperty("cpu");
 			expect(body).not.toHaveProperty("memory");
 			expect(body).not.toHaveProperty("allowInternetAccess");
+			expect(body).not.toHaveProperty("autoIdleTimeoutSeconds");
 			expect(body).not.toHaveProperty("envVars");
 			expect(body).not.toHaveProperty("secretRefs");
 		});
@@ -112,6 +122,19 @@ describe("Sandbox", () => {
 				{ name: "BAZ", value: "qux" },
 			]);
 			expect(body.secretRefs).toEqual(["my-secret"]);
+		});
+
+		it("forwards autoIdleTimeoutSeconds", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", status: "Pending" }));
+
+			await Sandbox.create("python:3.10", {
+				...defaultConfig,
+				autoIdleTimeoutSeconds: 1800,
+			});
+
+			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			expect(body.autoIdleTimeoutSeconds).toBe(1800);
 		});
 	});
 

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -704,6 +704,30 @@ describe("Sandbox", () => {
 			}
 		}, 10000);
 
+		it("waitUntilReady_retries_warmup_gateway_timeout", async () => {
+			const mockFetch = vi.mocked(fetch);
+			// fromPool
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			// refresh: Running
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			// first warmup probe times out at Agent Gateway, second succeeds
+			mockFetch.mockResolvedValueOnce(mockResponse("upstream request timeout", 504));
+			mockFetch.mockImplementationOnce(async (input, init) => {
+				const body = JSON.parse(String(init?.body ?? "{}"));
+				const match = String(body.code ?? "").match(/print\("(__pk_warmup_[a-f0-9]+__)"\)/);
+				return mockResponse({
+					stdout: `${match?.[1] ?? ""}\n`,
+					stderr: "",
+					success: true,
+					durationMs: 5,
+					session_id: "sess-warm",
+				});
+			});
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			await expect(sbx.waitUntilReady(30)).resolves.toBeUndefined();
+		});
+
 		it("waitUntilReady_propagates_runCode_errors_from_probe", async () => {
 			// If runCode itself throws (e.g., backend unreachable), the warmup
 			// probe must propagate the exception rather than swallow it — that


### PR DESCRIPTION
## Summary
- remove the consumer-install `prepare` build hook from the SDK package
- move TypeScript/tsup/@types/node build tooling out of runtime dependencies
- add an npm production-install smoke test that packs the built tarball, installs it with `--omit=dev`, verifies ESM/CJS imports, and checks build tooling is not installed as runtime deps
- run the new smoke test in the release workflow before uploading the tarball
- expose `autoIdleTimeoutSeconds` in the SDK for direct sandbox creation, warm-pool defaults, and per-claim overrides so Helm remains only the platform fallback

Addresses Phase 1 of #29. Registry publishing remains intentionally deferred to a follow-up Phase 2.

## Testing
- `git diff --check`
- `npx biome check package.json scripts/smoke-release-npm.mjs`
- `npx biome check src/sandbox/models.ts src/sandbox/client.ts src/sandbox/pool-client.ts src/sandbox/sandbox.ts src/sandbox/pool.ts tests/client.test.ts tests/pool-client.test.ts tests/sandbox.test.ts tests/pool.test.ts tests/models.test.ts`
- `npm run typecheck`
- `npm test` (155 tests)
- `npm run build`
- `npm run smoke:release:npm`

## Notes
- Full `npm run lint` remains blocked by existing unrelated formatting/lint issues outside the changed files.
- Existing npm audit vulnerabilities are present on the default branch and were not changed by this Phase 1 packaging fix.