### PR TITLE
fix: mirror Agent Gateway sandbox routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,15 @@ Configuration can be provided via environment variables or explicitly.
 ```bash
 export PROKUBE_API_URL=https://prokube.ai/pkui  # Can include path prefix
 export PROKUBE_WORKSPACE=my-workspace
-export PROKUBE_USER_ID=user@example.com  # Required if no API key (or KF_USER)
+export PROKUBE_API_KEY=your-api-key  # Required for external access
 export PROKUBE_TIMEOUT=300  # Optional, default 300 seconds
 ```
 
-**Note:** Authentication requires one of: `PROKUBE_API_KEY`, `PROKUBE_USER_ID`, or
-`KF_USER` (precedence in that order). `PROKUBE_API_KEY` enables external access;
-`PROKUBE_USER_ID` and `KF_USER` are for in-cluster usage. If none are set, you must
-pass `apiKey` or `userId` explicitly when creating a Sandbox.
+**Note:** `PROKUBE_API_KEY` enables external access and routes requests to the
+external `/sandbox/{workspace}/...` endpoints. In Kubernetes, if no API key and
+no `PROKUBE_API_URL` are configured, the SDK defaults to the in-cluster Agent
+Gateway service and routes sandbox requests to `/_platform/sandbox/{workspace}/...`.
+Outside Kubernetes, `PROKUBE_API_URL` is still required.
 
 ### Explicit Configuration
 
@@ -123,8 +124,29 @@ import { Sandbox } from "prokube";
 const sbx = await Sandbox.fromPool("python-pool", {
   apiUrl: "https://prokube.ai/pkui",
   workspace: "my-workspace",
-  userId: "user@example.com",
+  apiKey: "your-api-key",
 });
+```
+
+### In-Cluster / Notebook Usage
+
+Inside a Kubernetes notebook or workload, configure only the workspace when you
+do not need external API-key access. The SDK detects Kubernetes via
+`KUBERNETES_SERVICE_HOST`, uses the in-cluster Agent Gateway service, and sends
+no SDK auth headers unless you explicitly provide `PROKUBE_USER_ID`, `KF_USER`,
+or `apiKey`.
+
+```bash
+export PROKUBE_WORKSPACE=my-workspace
+```
+
+```typescript
+import { Sandbox } from "prokube";
+
+const sbx = await Sandbox.fromPool("python-pool");
+const result = await sbx.runCode("print('Hello from inside the cluster!')");
+console.log(result.stdout);
+await sbx.kill();
 ```
 
 ### External Access (API Key)

--- a/src/common/auth.ts
+++ b/src/common/auth.ts
@@ -1,5 +1,4 @@
 import type { Config } from "./config.js";
-import { AuthenticationError } from "./errors.js";
 
 export function getAuthHeaders(config: Config): Record<string, string> {
 	if (config.apiKey) {
@@ -8,9 +7,5 @@ export function getAuthHeaders(config: Config): Record<string, string> {
 	if (config.userId) {
 		return { "kubeflow-userid": config.userId };
 	}
-	throw new AuthenticationError(
-		"No authentication credentials found. " +
-			"Set PROKUBE_API_KEY or PROKUBE_USER_ID environment variable, " +
-			"or pass apiKey/userId option.",
-	);
+	return {};
 }

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -6,6 +6,9 @@ export interface ConfigOptions {
 	timeout?: number;
 }
 
+const IN_CLUSTER_AGENT_GATEWAY_URL =
+	"http://agentgateway-proxy.agentgateway-system.svc.cluster.local";
+
 export class Config {
 	readonly apiUrl: string;
 	readonly workspace: string;
@@ -14,7 +17,13 @@ export class Config {
 	readonly timeout: number;
 
 	constructor(options: ConfigOptions = {}) {
-		const apiUrl = options.apiUrl ?? process.env.PROKUBE_API_URL;
+		this.apiKey = emptyToUndefined(options.apiKey ?? process.env.PROKUBE_API_KEY);
+		const apiUrl =
+			options.apiUrl ??
+			process.env.PROKUBE_API_URL ??
+			(this.apiKey == null && process.env.KUBERNETES_SERVICE_HOST
+				? IN_CLUSTER_AGENT_GATEWAY_URL
+				: undefined);
 		const workspace = options.workspace ?? process.env.PROKUBE_WORKSPACE;
 
 		if (!apiUrl) {
@@ -30,7 +39,6 @@ export class Config {
 
 		this.apiUrl = apiUrl.replace(/\/+$/, "");
 		this.workspace = workspace;
-		this.apiKey = emptyToUndefined(options.apiKey ?? process.env.PROKUBE_API_KEY);
 		this.userId = emptyToUndefined(
 			options.userId ?? process.env.PROKUBE_USER_ID ?? process.env.KF_USER,
 		);

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -42,7 +42,7 @@ export class SandboxClient {
 		if (this.http.config.useApiKey) {
 			return `/sandbox/${this.workspace}/sandboxes`;
 		}
-		return `/api/namespaces/${this.workspace}/sandboxes`;
+		return `/_platform/sandbox/${this.workspace}/sandboxes`;
 	}
 
 	private sandboxPath(name: string): string {

--- a/src/sandbox/pool-client.ts
+++ b/src/sandbox/pool-client.ts
@@ -18,7 +18,7 @@ export class PoolClient {
 		if (this.http.config.useApiKey) {
 			return `/sandbox/${this.workspace}/sandbox-pools`;
 		}
-		return `/api/namespaces/${this.workspace}/sandbox-pools`;
+		return `/_platform/sandbox/${this.workspace}/sandbox-pools`;
 	}
 
 	private poolPath(name: string): string {

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { getAuthHeaders } from "../src/common/auth.js";
 import { Config } from "../src/common/config.js";
-import { AuthenticationError } from "../src/common/errors.js";
 
 describe("getAuthHeaders", () => {
 	it("returns x-api-key header when api_key is set", () => {
@@ -34,15 +33,11 @@ describe("getAuthHeaders", () => {
 		expect(getAuthHeaders(config)).toEqual({ "x-api-key": "my-key" });
 	});
 
-	it("throws AuthenticationError when no credentials", () => {
+	it("returns no auth headers when no credentials are configured", () => {
 		const config = new Config({
 			apiUrl: "https://example.com",
 			workspace: "ns",
-			userId: "placeholder",
 		});
-		// Manually remove userId to simulate missing credentials
-		Object.defineProperty(config, "userId", { value: undefined });
-		Object.defineProperty(config, "apiKey", { value: undefined });
-		expect(() => getAuthHeaders(config)).toThrow(AuthenticationError);
+		expect(getAuthHeaders(config)).toEqual({});
 	});
 });

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -30,7 +30,7 @@ describe("SandboxClient", () => {
 	});
 
 	describe("path routing", () => {
-		it("uses internal paths for user_id auth", async () => {
+		it("uses Agent Gateway platform paths for no-api-key auth", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ sandboxes: [], total: 0 }));
 
@@ -38,7 +38,21 @@ describe("SandboxClient", () => {
 			await client.list();
 
 			const url = mockFetch.mock.calls[0][0] as string;
-			expect(url).toContain("/api/namespaces/test-ns/sandboxes");
+			expect(url).toContain("/_platform/sandbox/test-ns/sandboxes");
+		});
+
+		it("uses Agent Gateway platform paths without auth headers", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ sandboxes: [], total: 0 }));
+
+			const client = new SandboxClient(makeConfig({ userId: undefined }));
+			await client.list();
+
+			const url = mockFetch.mock.calls[0][0] as string;
+			const headers = mockFetch.mock.calls[0][1]?.headers as Record<string, string>;
+			expect(url).toContain("/_platform/sandbox/test-ns/sandboxes");
+			expect(headers["x-api-key"]).toBeUndefined();
+			expect(headers["kubeflow-userid"]).toBeUndefined();
 		});
 
 		it("uses external paths for api_key auth", async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -12,6 +12,7 @@ describe("Config", () => {
 		process.env.PROKUBE_API_KEY = undefined;
 		process.env.PROKUBE_TIMEOUT = undefined;
 		process.env.KF_USER = undefined;
+		process.env.KUBERNETES_SERVICE_HOST = undefined;
 	});
 
 	afterEach(() => {
@@ -64,6 +65,25 @@ describe("Config", () => {
 
 	it("throws when api_url is missing", () => {
 		expect(() => new Config({ workspace: "ns" })).toThrow("api_url is required");
+	});
+
+	it("defaults API URL to Agent Gateway in Kubernetes without API key", () => {
+		process.env.KUBERNETES_SERVICE_HOST = "10.0.0.1";
+		const config = new Config({ workspace: "ns" });
+		expect(config.apiUrl).toBe("http://agentgateway-proxy.agentgateway-system.svc.cluster.local");
+		expect(config.useApiKey).toBe(false);
+	});
+
+	it("does not default API URL in Kubernetes when API key is set", () => {
+		process.env.KUBERNETES_SERVICE_HOST = "10.0.0.1";
+		expect(() => new Config({ workspace: "ns", apiKey: "key" })).toThrow("api_url is required");
+	});
+
+	it("allows in-cluster config without SDK auth credentials", () => {
+		process.env.KUBERNETES_SERVICE_HOST = "10.0.0.1";
+		const config = new Config({ workspace: "ns" });
+		expect(config.apiKey).toBeUndefined();
+		expect(config.userId).toBeUndefined();
 	});
 
 	it("throws when workspace is missing", () => {

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -106,6 +106,19 @@ describe("HttpClient", () => {
 		expect(headers["kubeflow-userid"]).toBe("user@test.com");
 	});
 
+	it("does not require SDK auth headers without api_key or user_id", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+		const client = new HttpClient(makeConfig({ userId: undefined }));
+		await client.get("/_platform/sandbox/ns/sandboxes");
+
+		const headers = mockFetch.mock.calls[0][1]?.headers as Record<string, string>;
+		expect(headers["x-api-key"]).toBeUndefined();
+		expect(headers["kubeflow-userid"]).toBeUndefined();
+		expect(headers["content-type"]).toBe("application/json");
+	});
+
 	it("uses origin-only base URL for API key auth", async () => {
 		const mockFetch = vi.mocked(fetch);
 		mockFetch.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
@@ -118,14 +131,14 @@ describe("HttpClient", () => {
 		expect(url).not.toContain("/pkui");
 	});
 
-	it("preserves path prefix for internal auth", async () => {
+	it("preserves path prefix for no-api-key access", async () => {
 		const mockFetch = vi.mocked(fetch);
 		mockFetch.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
 
 		const client = new HttpClient(makeConfig());
-		await client.get("/api/namespaces/ns/sandboxes");
+		await client.get("/_platform/sandbox/ns/sandboxes");
 
 		const url = mockFetch.mock.calls[0][0] as string;
-		expect(url).toBe("https://example.com/pkui/api/namespaces/ns/sandboxes");
+		expect(url).toBe("https://example.com/pkui/_platform/sandbox/ns/sandboxes");
 	});
 });

--- a/tests/pool-client.test.ts
+++ b/tests/pool-client.test.ts
@@ -38,7 +38,7 @@ describe("PoolClient", () => {
 	});
 
 	describe("path routing", () => {
-		it("uses internal paths for user_id auth", async () => {
+		it("uses Agent Gateway platform paths for no-api-key auth", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ pools: [], total: 0 }));
 
@@ -46,7 +46,21 @@ describe("PoolClient", () => {
 			await client.list();
 
 			const url = mockFetch.mock.calls[0][0] as string;
-			expect(url).toContain("/api/namespaces/test-ns/sandbox-pools");
+			expect(url).toContain("/_platform/sandbox/test-ns/sandbox-pools");
+		});
+
+		it("uses Agent Gateway platform paths without auth headers", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ pools: [], total: 0 }));
+
+			const client = new PoolClient(makeConfig({ userId: undefined }));
+			await client.list();
+
+			const url = mockFetch.mock.calls[0][0] as string;
+			const headers = mockFetch.mock.calls[0][1]?.headers as Record<string, string>;
+			expect(url).toContain("/_platform/sandbox/test-ns/sandbox-pools");
+			expect(headers["x-api-key"]).toBeUndefined();
+			expect(headers["kubeflow-userid"]).toBeUndefined();
 		});
 
 		it("uses external paths for api_key auth", async () => {

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -17,11 +17,21 @@ const defaultConfig = {
 };
 
 describe("Sandbox", () => {
+	const originalEnv = process.env;
+
 	beforeEach(() => {
+		process.env = { ...originalEnv };
+		process.env.PROKUBE_API_URL = undefined;
+		process.env.PROKUBE_WORKSPACE = undefined;
+		process.env.PROKUBE_USER_ID = undefined;
+		process.env.PROKUBE_API_KEY = undefined;
+		process.env.KF_USER = undefined;
+		process.env.KUBERNETES_SERVICE_HOST = undefined;
 		vi.stubGlobal("fetch", vi.fn());
 	});
 
 	afterEach(() => {
+		process.env = originalEnv;
 		vi.restoreAllMocks();
 	});
 
@@ -33,6 +43,24 @@ describe("Sandbox", () => {
 			const sbx = await Sandbox.fromPool("gpu-pool", defaultConfig);
 			expect(sbx.name).toBe("sb-pool-1");
 			expect(sbx.status).toBe(SandboxStatus.Running);
+		});
+
+		it("claims from Agent Gateway in Kubernetes without SDK auth", async () => {
+			process.env.KUBERNETES_SERVICE_HOST = "10.0.0.1";
+			process.env.PROKUBE_WORKSPACE = "test-ns";
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ name: "sb-pool-1", status: "Running" }));
+
+			const sbx = await Sandbox.fromPool("gpu-pool");
+
+			const url = mockFetch.mock.calls[0][0] as string;
+			const headers = mockFetch.mock.calls[0][1]?.headers as Record<string, string>;
+			expect(sbx.name).toBe("sb-pool-1");
+			expect(url).toBe(
+				"http://agentgateway-proxy.agentgateway-system.svc.cluster.local/_platform/sandbox/test-ns/sandboxes/claim",
+			);
+			expect(headers["x-api-key"]).toBeUndefined();
+			expect(headers["kubeflow-userid"]).toBeUndefined();
 		});
 
 		it("sends volumeSize when provided", async () => {


### PR DESCRIPTION
## Summary
- Route no-API-key sandbox and sandbox-pool requests through Agent Gateway platform paths
- Allow in-cluster no-API-key usage without SDK auth headers and default to the in-cluster Agent Gateway service only in Kubernetes
- Keep external API-key routing on origin-only /sandbox/{workspace}/... paths
- Update tests and README notebook/in-cluster usage docs

Closes #31

## Testing
- npm test
- npm run typecheck
- npm run build
- npx biome check src/common/config.ts src/common/auth.ts src/sandbox/client.ts src/sandbox/pool-client.ts tests/config.test.ts tests/auth.test.ts tests/http.test.ts tests/client.test.ts tests/pool-client.test.ts tests/sandbox.test.ts README.md

## Notes
- npm run lint still reports pre-existing formatting issues in unrelated files (scripts and smoke test fixtures); touched files pass Biome.