### PR TITLE
fix: Handle warm pool exhaustion

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,12 @@ ProKubeError (base)
 │   └── PoolExhaustedError
 ```
 
+`Sandbox.fromPool()` rejects with `PoolExhaustedError` when the backend returns
+HTTP 429 with `reason` or `error` set to `pool_exhausted`. Treat this as
+retryable backpressure: no warm pool capacity is currently available. The error
+has `statusCode: 429`, `reason: "pool_exhausted"`, and preserves the optional
+`Retry-After` response header as `retryAfter`.
+
 ## Development
 
 ```bash

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -85,8 +85,12 @@ export class PoolNotFoundError extends SandboxError {
  * Raised when no sandboxes are available in the warm pool.
  */
 export class PoolExhaustedError extends SandboxError {
-	constructor(message: string) {
-		super(message);
+	readonly reason = "pool_exhausted";
+	readonly retryAfter: string | undefined;
+
+	constructor(message: string, retryAfter?: string) {
+		super(message, 429);
 		this.name = "PoolExhaustedError";
+		this.retryAfter = retryAfter;
 	}
 }

--- a/src/common/http.ts
+++ b/src/common/http.ts
@@ -105,7 +105,12 @@ export class HttpClient {
 		} catch {
 			detail = response.statusText;
 		}
-		const reason = stringValue(body.reason) ?? stringValue(body.error);
+		const detailBody = objectValue(body.detail);
+		const reason =
+			stringValue(body.reason) ??
+			stringValue(body.error) ??
+			stringValue(detailBody?.reason) ??
+			stringValue(detailBody?.error);
 
 		if (response.status === 429 && reason === "pool_exhausted") {
 			throw new PoolExhaustedError(
@@ -128,4 +133,10 @@ export class HttpClient {
 
 function stringValue(value: unknown): string | undefined {
 	return typeof value === "string" ? value : undefined;
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
 }

--- a/src/common/http.ts
+++ b/src/common/http.ts
@@ -101,7 +101,12 @@ export class HttpClient {
 		let detail: string;
 		try {
 			body = (await response.json()) as ErrorResponseBody;
-			detail = stringValue(body.detail) ?? stringValue(body.message) ?? response.statusText;
+			const detailBody = objectValue(body.detail);
+			detail =
+				stringValue(body.detail) ??
+				stringValue(body.message) ??
+				stringValue(detailBody?.message) ??
+				response.statusText;
 		} catch {
 			detail = response.statusText;
 		}

--- a/src/common/http.ts
+++ b/src/common/http.ts
@@ -1,6 +1,13 @@
 import { getAuthHeaders } from "./auth.js";
 import type { Config } from "./config.js";
-import { AuthenticationError, NotFoundError, ProKubeError } from "./errors.js";
+import { AuthenticationError, NotFoundError, PoolExhaustedError, ProKubeError } from "./errors.js";
+
+interface ErrorResponseBody {
+	detail?: unknown;
+	error?: unknown;
+	message?: unknown;
+	reason?: unknown;
+}
 
 export class HttpClient {
 	readonly config: Config;
@@ -90,12 +97,21 @@ export class HttpClient {
 	private async handleError(response: Response): Promise<void> {
 		if (response.ok) return;
 
+		let body: ErrorResponseBody = {};
 		let detail: string;
 		try {
-			const data = (await response.json()) as { detail?: string };
-			detail = data.detail ?? response.statusText;
+			body = (await response.json()) as ErrorResponseBody;
+			detail = stringValue(body.detail) ?? stringValue(body.message) ?? response.statusText;
 		} catch {
 			detail = response.statusText;
+		}
+		const reason = stringValue(body.reason) ?? stringValue(body.error);
+
+		if (response.status === 429 && reason === "pool_exhausted") {
+			throw new PoolExhaustedError(
+				detail || "No warm pool capacity is currently available; retry the claim later.",
+				response.headers.get("retry-after") ?? undefined,
+			);
 		}
 
 		const message = `HTTP ${response.status}: ${detail}`;
@@ -108,4 +124,8 @@ export class HttpClient {
 		}
 		throw new ProKubeError(message, response.status);
 	}
+}
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
 }

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Config } from "../src/common/config.js";
-import { SandboxError } from "../src/common/errors.js";
+import { PoolExhaustedError, SandboxError } from "../src/common/errors.js";
 import { SandboxClient } from "../src/sandbox/client.js";
 import { SandboxStatus } from "../src/sandbox/models.js";
 
@@ -102,6 +102,33 @@ describe("SandboxClient", () => {
 
 			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
 			expect(body.autoIdleTimeoutSeconds).toBe(900);
+		});
+
+		it("throws PoolExhaustedError for retryable 429 pool exhaustion", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						reason: "pool_exhausted",
+						detail: "No warm pool capacity is currently available",
+					}),
+					{
+						status: 429,
+						headers: { "content-type": "application/json", "retry-after": "15" },
+					},
+				),
+			);
+
+			const client = new SandboxClient(makeConfig());
+			try {
+				await client.claimFromPool("pool");
+				throw new Error("Expected PoolExhaustedError");
+			} catch (error) {
+				expect(error).toBeInstanceOf(PoolExhaustedError);
+				const poolError = error as PoolExhaustedError;
+				expect(poolError.reason).toBe("pool_exhausted");
+				expect(poolError.retryAfter).toBe("15");
+			}
 		});
 	});
 

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -57,6 +57,10 @@ describe("Error hierarchy", () => {
 	});
 
 	it("PoolExhaustedError inherits from SandboxError", () => {
-		expect(new PoolExhaustedError("exhausted")).toBeInstanceOf(SandboxError);
+		const err = new PoolExhaustedError("exhausted", "5");
+		expect(err).toBeInstanceOf(SandboxError);
+		expect(err.statusCode).toBe(429);
+		expect(err.reason).toBe("pool_exhausted");
+		expect(err.retryAfter).toBe("5");
 	});
 });

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -142,6 +142,36 @@ describe("HttpClient", () => {
 		await expect(client.post("/claim", {})).rejects.toThrow(PoolExhaustedError);
 	});
 
+	it("supports FastAPI nested detail pool exhaustion responses", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					detail: {
+						reason: "pool_exhausted",
+						message: "Warm pool has no ready capacity.",
+						poolName: "python-pool",
+					},
+				}),
+				{
+					status: 429,
+					headers: { "content-type": "application/json", "retry-after": "1" },
+				},
+			),
+		);
+
+		const client = new HttpClient(makeConfig());
+		try {
+			await client.post("/claim", { poolName: "python-pool" });
+			throw new Error("Expected PoolExhaustedError");
+		} catch (error) {
+			expect(error).toBeInstanceOf(PoolExhaustedError);
+			const poolError = error as PoolExhaustedError;
+			expect(poolError.reason).toBe("pool_exhausted");
+			expect(poolError.retryAfter).toBe("1");
+		}
+	});
+
 	it("includes kubeflow-userid header for internal auth", async () => {
 		const mockFetch = vi.mocked(fetch);
 		mockFetch.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Config } from "../src/common/config.js";
-import { AuthenticationError, NotFoundError, ProKubeError } from "../src/common/errors.js";
+import {
+	AuthenticationError,
+	NotFoundError,
+	PoolExhaustedError,
+	ProKubeError,
+} from "../src/common/errors.js";
 import { HttpClient } from "../src/common/http.js";
 
 function makeConfig(overrides: Partial<{ apiKey: string; userId: string }> = {}): Config {
@@ -93,6 +98,48 @@ describe("HttpClient", () => {
 
 		const client = new HttpClient(makeConfig());
 		await expect(client.get("/api/secure")).rejects.toThrow(AuthenticationError);
+	});
+
+	it("throws PoolExhaustedError for retryable pool exhaustion", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					reason: "pool_exhausted",
+					detail: "No warm pool capacity is currently available",
+				}),
+				{
+					status: 429,
+					headers: { "content-type": "application/json", "retry-after": "10" },
+				},
+			),
+		);
+
+		const client = new HttpClient(makeConfig());
+		try {
+			await client.post("/_platform/sandbox/test-ns/sandboxes/claim", { poolName: "pool" });
+			throw new Error("Expected PoolExhaustedError");
+		} catch (error) {
+			expect(error).toBeInstanceOf(PoolExhaustedError);
+			const poolError = error as PoolExhaustedError;
+			expect(poolError.statusCode).toBe(429);
+			expect(poolError.reason).toBe("pool_exhausted");
+			expect(poolError.retryAfter).toBe("10");
+			expect(poolError.message).toContain("No warm pool capacity");
+		}
+	});
+
+	it("supports pool exhaustion responses using error field", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValue(
+			new Response(JSON.stringify({ error: "pool_exhausted", message: "Pool is empty" }), {
+				status: 429,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		const client = new HttpClient(makeConfig());
+		await expect(client.post("/claim", {})).rejects.toThrow(PoolExhaustedError);
 	});
 
 	it("includes kubeflow-userid header for internal auth", async () => {

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -169,6 +169,7 @@ describe("HttpClient", () => {
 			const poolError = error as PoolExhaustedError;
 			expect(poolError.reason).toBe("pool_exhausted");
 			expect(poolError.retryAfter).toBe("1");
+			expect(poolError.message).toContain("Warm pool has no ready capacity");
 		}
 	});
 

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { SandboxError } from "../src/common/errors.js";
+import { PoolExhaustedError, SandboxError } from "../src/common/errors.js";
 import { SandboxStatus } from "../src/sandbox/models.js";
 import { Sandbox } from "../src/sandbox/sandbox.js";
 
@@ -80,6 +80,34 @@ describe("Sandbox", () => {
 			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
 			expect(body.autoIdleTimeoutSeconds).toBe(900);
 			expect(sbx.autoIdleTimeoutSeconds).toBe(900);
+		});
+
+		it("surfaces retryable pool exhaustion distinctly", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						reason: "pool_exhausted",
+						detail: "No warm pool capacity is currently available",
+					}),
+					{
+						status: 429,
+						headers: { "content-type": "application/json", "retry-after": "20" },
+					},
+				),
+			);
+
+			try {
+				await Sandbox.fromPool("pool", defaultConfig);
+				throw new Error("Expected PoolExhaustedError");
+			} catch (error) {
+				expect(error).toBeInstanceOf(PoolExhaustedError);
+				const poolError = error as PoolExhaustedError;
+				expect(poolError.statusCode).toBe(429);
+				expect(poolError.reason).toBe("pool_exhausted");
+				expect(poolError.retryAfter).toBe("20");
+				expect(poolError.message).toContain("No warm pool capacity");
+			}
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Map structured WarmPool claim exhaustion responses to PoolExhaustedError
- Preserve retry-after guidance on the structured SDK error
- Cover pool exhaustion in HTTP, claimFromPool, and Sandbox.fromPool tests
- Document retryable PoolExhaustedError behavior

Closes #36

## Testing
- npx biome format --write README.md src/common/errors.ts src/common/http.ts tests/client.test.ts tests/errors.test.ts tests/http.test.ts tests/sandbox.test.ts
- npx biome check README.md src/common/errors.ts src/common/http.ts tests/client.test.ts tests/errors.test.ts tests/http.test.ts tests/sandbox.test.ts
- npm run typecheck
- npm test

## Caveats
- npm run lint still fails on pre-existing formatting/import-order issues in unrelated script and smoke-test files.