### PR TITLE
feat: add paginated sandbox listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,23 @@ API endpoints.
 
 The main class for interacting with sandboxes.
 
+Paginate large sandbox collections without loading the full workspace history:
+
+```typescript
+let page = await Sandbox.listPage({ lifecycle: "inactive", limit: 10 });
+for (const sandbox of page.sandboxes) {
+	console.log(sandbox.name);
+}
+
+if (page.hasMore) {
+	page = await Sandbox.listPage({
+		lifecycle: "inactive",
+		limit: 10,
+		continueToken: page.continueToken,
+	});
+}
+```
+
 ```typescript
 class Sandbox {
   name: string;       // Sandbox name

--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ The main class for interacting with sandboxes.
 
 Paginate large sandbox collections without loading the full workspace history:
 
+- `active` (default): user sandboxes in `Running` or `Pending` phase.
+- `inactive`: user sandboxes in `Paused`, `Succeeded`, or `Failed` phase.
+
+Idle warm-pool capacity is internal infrastructure and is excluded from both
+lifecycles.
+
 ```typescript
 let page = await Sandbox.listPage({ lifecycle: "inactive", limit: 10 });
 for (const sandbox of page.sandboxes) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ export {
 	Sandbox,
 	type SandboxOptions,
 	type SandboxCreateOptions,
+	type SandboxPage,
+	type SandboxPageOptions,
 } from "./sandbox/sandbox.js";
 export { SandboxPool, type CreatePoolOptions } from "./sandbox/pool.js";
 export { SandboxClient } from "./sandbox/client.js";
@@ -12,6 +14,8 @@ export { FileManager } from "./sandbox/files.js";
 export {
 	SandboxStatus,
 	type SandboxInfo,
+	type SandboxInfoPage,
+	type SandboxLifecycle,
 	type PoolInfo,
 	type CreateSandboxRequest,
 	type CreatePoolRequest,

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -139,7 +139,7 @@ export class SandboxClient {
 			limit: String(limit),
 			lifecycle,
 		};
-		if (options.continueToken) params.continueToken = options.continueToken;
+		if (options.continueToken !== undefined) params.continueToken = options.continueToken;
 		const data = (await this.http.get(this.sandboxesPath(), params)) as Record<string, unknown>;
 		const rawSandboxes = (data.sandboxes ?? []) as Record<string, unknown>[];
 		const sandboxes = rawSandboxes.map((sandbox) => parseSandboxInfo(sandbox, this.workspace));

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -16,6 +16,8 @@ import {
 	type FileInfo,
 	type FileWriteInput,
 	type SandboxInfo,
+	type SandboxInfoPage,
+	type SandboxLifecycle,
 	SandboxStatus,
 	parseBatchFileWriteResponse,
 	parseCodeResult,
@@ -118,6 +120,35 @@ export class SandboxClient {
 		const data = (await this.http.get(this.sandboxesPath())) as Record<string, unknown>;
 		const sandboxes = (data.sandboxes ?? []) as Record<string, unknown>[];
 		return sandboxes.map((s) => parseSandboxInfo(s, this.workspace));
+	}
+
+	async listPage(
+		options: {
+			lifecycle?: SandboxLifecycle;
+			limit?: number;
+			continueToken?: string;
+		} = {},
+	): Promise<SandboxInfoPage> {
+		const lifecycle = options.lifecycle ?? "active";
+		const limit = options.limit ?? 25;
+		if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+			throw new RangeError("limit must be an integer between 1 and 100");
+		}
+
+		const params: Record<string, string> = {
+			limit: String(limit),
+			lifecycle,
+		};
+		if (options.continueToken) params.continueToken = options.continueToken;
+		const data = (await this.http.get(this.sandboxesPath(), params)) as Record<string, unknown>;
+		const rawSandboxes = (data.sandboxes ?? []) as Record<string, unknown>[];
+		const sandboxes = rawSandboxes.map((sandbox) => parseSandboxInfo(sandbox, this.workspace));
+		return {
+			sandboxes,
+			loaded: typeof data.loaded === "number" ? data.loaded : sandboxes.length,
+			hasMore: data.hasMore === true,
+			continueToken: typeof data.continueToken === "string" ? data.continueToken : undefined,
+		};
 	}
 
 	async get(name: string): Promise<SandboxInfo> {

--- a/src/sandbox/models.ts
+++ b/src/sandbox/models.ts
@@ -19,6 +19,15 @@ export interface SandboxInfo {
 	resumedFromPool?: boolean;
 }
 
+export type SandboxLifecycle = "active" | "inactive";
+
+export interface SandboxInfoPage {
+	sandboxes: SandboxInfo[];
+	loaded: number;
+	hasMore: boolean;
+	continueToken?: string;
+}
+
 export interface CodeResult {
 	stdout: string;
 	stderr: string;

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -5,7 +5,13 @@ import { SandboxClient } from "./client.js";
 import { CodeRunner } from "./code.js";
 import { CommandRunner } from "./commands.js";
 import { FileManager } from "./files.js";
-import { type CodeResult, type EnvVar, type ResourceRequests, SandboxStatus } from "./models.js";
+import {
+	type CodeResult,
+	type EnvVar,
+	type ResourceRequests,
+	type SandboxLifecycle,
+	SandboxStatus,
+} from "./models.js";
 
 export interface SandboxOptions extends ConfigOptions {
 	volumeSize?: string;
@@ -30,6 +36,19 @@ export interface SandboxCreateOptions extends SandboxOptions {
 	envVars?: EnvVar[];
 	/** Names of Kubernetes secrets to mount/reference in the sandbox. */
 	secretRefs?: string[];
+}
+
+export interface SandboxPageOptions extends ConfigOptions {
+	lifecycle?: SandboxLifecycle;
+	limit?: number;
+	continueToken?: string;
+}
+
+export interface SandboxPage {
+	sandboxes: Sandbox[];
+	loaded: number;
+	hasMore: boolean;
+	continueToken?: string;
 }
 
 export class Sandbox {
@@ -188,6 +207,40 @@ export class Sandbox {
 							info.autoIdleTimeoutSeconds,
 						),
 				);
+		} finally {
+			client.close();
+		}
+	}
+
+	/**
+	 * List one bounded page of active or inactive sandboxes.
+	 *
+	 * Reuse the opaque continuation token with the same lifecycle and limit to
+	 * fetch the next page.
+	 */
+	static async listPage(options: SandboxPageOptions = {}): Promise<SandboxPage> {
+		const config = new Config(options);
+		const client = new SandboxClient(config);
+		try {
+			const page = await client.listPage(options);
+			return {
+				sandboxes: page.sandboxes.map(
+					(info) =>
+						new Sandbox(
+							info.name,
+							config.workspace,
+							new SandboxClient(config),
+							info.status,
+							config.timeout,
+							info.image,
+							info.pool,
+							info.autoIdleTimeoutSeconds,
+						),
+				),
+				loaded: page.loaded,
+				hasMore: page.hasMore,
+				continueToken: page.continueToken,
+			};
 		} finally {
 			client.close();
 		}

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -284,6 +284,18 @@ describe("SandboxClient", () => {
 				"limit must be an integer between 1 and 100",
 			);
 		});
+
+		it("forwards an explicitly provided empty continuation token", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ sandboxes: [], loaded: 0, hasMore: false }));
+
+			const client = new SandboxClient(makeConfig());
+			await client.listPage({ continueToken: "" });
+
+			const url = new URL(mockFetch.mock.calls[0][0] as string);
+			expect(url.searchParams.has("continueToken")).toBe(true);
+			expect(url.searchParams.get("continueToken")).toBe("");
+		});
 	});
 
 	describe("pause/resume", () => {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -248,6 +248,42 @@ describe("SandboxClient", () => {
 			expect(result[1].name).toBe("sb-2");
 			expect(result[1].status).toBe(SandboxStatus.Paused);
 		});
+
+		it("lists one page and preserves pagination metadata", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(
+				mockResponse({
+					sandboxes: [{ name: "paused-1", phase: "Paused" }],
+					loaded: 1,
+					hasMore: true,
+					continueToken: "next-token",
+				}),
+			);
+
+			const client = new SandboxClient(makeConfig());
+			const page = await client.listPage({
+				lifecycle: "inactive",
+				limit: 10,
+				continueToken: "opaque-token",
+			});
+
+			expect(page.sandboxes[0].name).toBe("paused-1");
+			expect(page.sandboxes[0].status).toBe(SandboxStatus.Paused);
+			expect(page.loaded).toBe(1);
+			expect(page.hasMore).toBe(true);
+			expect(page.continueToken).toBe("next-token");
+			const url = new URL(mockFetch.mock.calls[0][0] as string);
+			expect(url.searchParams.get("limit")).toBe("10");
+			expect(url.searchParams.get("lifecycle")).toBe("inactive");
+			expect(url.searchParams.get("continueToken")).toBe("opaque-token");
+		});
+
+		it("validates the page limit", async () => {
+			const client = new SandboxClient(makeConfig());
+			await expect(client.listPage({ limit: 101 })).rejects.toThrow(
+				"limit must be an integer between 1 and 100",
+			);
+		});
 	});
 
 	describe("pause/resume", () => {

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -264,6 +264,31 @@ describe("Sandbox", () => {
 			expect(result).toHaveLength(2);
 			expect(result.every((s) => s.status === SandboxStatus.Paused)).toBe(true);
 		});
+
+		it("returns one page of ready-to-use sandboxes", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(
+				mockResponse({
+					sandboxes: [{ name: "paused-1", status: "Paused" }],
+					loaded: 1,
+					hasMore: true,
+					continueToken: "next-token",
+				}),
+			);
+
+			const page = await Sandbox.listPage({
+				...defaultConfig,
+				lifecycle: "inactive",
+				limit: 10,
+			});
+
+			expect(page.sandboxes).toHaveLength(1);
+			expect(page.sandboxes[0].name).toBe("paused-1");
+			expect(page.sandboxes[0].status).toBe(SandboxStatus.Paused);
+			expect(page.loaded).toBe(1);
+			expect(page.hasMore).toBe(true);
+			expect(page.continueToken).toBe("next-token");
+		});
 	});
 
 	describe("runCode", () => {


### PR DESCRIPTION
## Summary
- add `Sandbox.listPage()` for bounded active and inactive sandbox pages
- add low-level `SandboxClient.listPage()` and exported pagination types
- preserve the existing unbounded `list()` behavior for compatibility
- document opaque continuation-token usage

## Validation
- `177 passed`
- TypeScript typecheck passed
- package build and declaration validation passed
- changed files pass Biome

Repository-wide Biome still reports pre-existing formatting issues in release scripts and smoke fixtures.