### PR TITLE
feat!: pk-sandbox v0.8 parity with Python SDK; release as v0.2.0

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  quality:
+    name: lint · types · tests (node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20.19.0"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint (biome check)
+        run: npm run lint
+
+      - name: Type check (tsc)
+        run: npm run typecheck
+
+      - name: Tests (vitest)
+        run: npm run test

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -24,12 +24,22 @@ jobs:
 
       - name: Validate release tag
         if: github.event_name == 'release'
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          expected_tag=$(node -e 'const version = require("./package.json").version; const [year, month, day] = version.split("."); console.log(`v${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`);')
-          if [ "$expected_tag" != "${{ github.event.release.tag_name }}" ]; then
-            echo "Expected release tag $expected_tag but got ${{ github.event.release.tag_name }}" >&2
-            exit 1
-          fi
+          node -e '
+            const version = require("./package.json").version;
+            if (!/^\d+\.\d+\.\d+$/.test(version)) {
+              console.error(`package.json version "${version}" is not semver X.Y.Z`);
+              process.exit(1);
+            }
+            const expected = `v${version}`;
+            const actual = process.env.RELEASE_TAG;
+            if (expected !== actual) {
+              console.error(`Expected release tag ${expected} but got ${actual}`);
+              process.exit(1);
+            }
+          '
 
       - name: Build, pack, and smoke test npm production install
         run: npm run smoke:release:npm

--- a/README.md
+++ b/README.md
@@ -445,6 +445,47 @@ npm run lint
 npm run build
 ```
 
+### E2E tests
+
+`tests/e2e/live-sandbox.test.ts` is a live acceptance suite: it drives the
+public SDK surface against a **real** pk-sandbox deployment and creates real,
+billable sandboxes and warm pools. It is excluded from `npm test` and from CI,
+and runs only through its own config:
+
+```bash
+npm run test:e2e
+```
+
+Without the three required variables every scenario skips and the command
+exits 0, so it is safe to run anywhere. With them set it exercises the full
+lifecycle (create → ready → stateful `runCode` → `resetSession` → commands →
+files → listing/pagination → pause → resume → kill), the warm-pool claim path,
+and the not-found / invalid-state error surface.
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `PROKUBE_API_URL` | yes | — | Backend base URL, e.g. `https://prokube.ai/pkui` |
+| `PROKUBE_WORKSPACE` | yes | — | Kubernetes namespace / workspace to run in |
+| `PROKUBE_API_KEY` | yes | — | API key for external access |
+| `SANDBOX_IMAGE` | no | `europe-west3-docker.pkg.dev/prokube-internal/prokube-customer/pk-sandbox-base:v14-05-2026` | Image used for every sandbox and for an ephemeral pool |
+| `SANDBOX_POOL` | no | _unset_ | Reuse this existing warm pool. When unset the suite creates an ephemeral pool and deletes it afterwards; a pre-existing pool is never deleted |
+| `SANDBOX_POOL_SIZE` | no | `5` | Positive integer, mirroring the Python suite. The ephemeral pool is capped at `min(SANDBOX_POOL_SIZE, 2)` to stay cheap — set `1` for the smallest run |
+| `SANDBOX_POOL_READY_TIMEOUT` | no | `120` | Seconds to wait for the pool to report a ready replica |
+
+`SANDBOX_POOL_SIZE` and `SANDBOX_POOL_READY_TIMEOUT` must parse as positive
+integers; anything else fails immediately with a message naming the variable.
+
+One-liner against a live cluster:
+
+```bash
+PROKUBE_API_URL=https://prokube.ai/pkui PROKUBE_WORKSPACE=my-workspace PROKUBE_API_KEY=$PK_KEY npm run test:e2e
+```
+
+Resource names are unique per run (`ts-e2e-<base36 timestamp>-…`), and every
+sandbox is killed and every ephemeral pool deleted in `afterAll` even when
+assertions fail. Env parsing itself lives in `tests/e2e/live-config.ts` and is
+unit-tested by `tests/live-config.test.ts`, which does run in `npm test`.
+
 ## Requirements
 
 - Node.js >= 20.19.0 (uses native `fetch`)

--- a/README.md
+++ b/README.md
@@ -278,8 +278,8 @@ moves through an intermediate phase before it settles.
   poll shares one timeout budget, so a single slow status request cannot exceed
   it. It throws `SandboxError` if the sandbox reaches `Failed` (the message
   carries `lastError`) or `Deleting`, and `SandboxTimeoutError` on timeout.
-- `SandboxStatus.Bound` is deprecated: v0.8 backends never return it. It is
-  kept in the enum so existing code compiles.
+- `SandboxStatus.Bound` and `SandboxInfo.resumedFromPool` were removed in
+  0.2.0 (matching the Python SDK): v0.8 backends never report them.
 
 #### Pagination
 
@@ -384,8 +384,7 @@ interface SandboxInfo {
   workspace: string;
   status: SandboxStatus;
   lastError?: string;        // Backend failure detail, set when status is Failed
-  resumedFromPool?: boolean; // @deprecated - no longer populated by v0.8 backends
-  // ...remaining fields unchanged
+  // ...remaining fields unchanged; the pre-0.8 resumedFromPool field was removed
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -256,8 +256,8 @@ moves through an intermediate phase before it settles.
 | `pause()` | sandbox reports `Paused` (default `wait: true`) | `Pausing` → `Paused` | — |
 | `pause({ wait: false })` | pause accepted | `Pausing` | poll `refresh()` / `status` |
 | `resume()` | resume accepted (never blocks) | `Resuming` | `waitUntilReady()` |
-| `kill()` | delete accepted (default `wait: false`) | `Deleting` | — |
-| `kill({ wait: true })` | sandbox is gone (HTTP 404) | `Deleting` → gone | — |
+| `kill()` | delete accepted (default `wait: false`) | local `status` flips to `Succeeded` at once | — |
+| `kill({ wait: true })` | sandbox is gone (HTTP 404) | local `status` flips to `Succeeded` once gone | — |
 
 - `pause(options)` defaults to `{ wait: true, timeout: 300 }` (seconds), so
   existing `await sbx.pause()` call sites keep blocking until `Paused`.
@@ -265,6 +265,13 @@ moves through an intermediate phase before it settles.
   includes an asynchronous persistence purge, and the sandbox name stays
   reserved until that purge finishes — pass `{ wait: true }` when you need to
   reuse the name or reclaim quota immediately.
+- `kill()` marks the sandbox dead locally the moment the delete is accepted:
+  `status` reads `Succeeded` and every further operation throws, even though
+  the backend is still tearing the pod down (its own phase is `Deleting`
+  until the record is purged). The local status is the SDK's "this handle is
+  finished" flag, not a backend phase reading — the handle's client is closed,
+  so it cannot report backend phases any more. Use `Sandbox.get(name)` if you
+  need to observe the backend-side teardown.
 - `waitUntilReady(timeout)` polls through `Pending` and `Resuming` until the
   phase is `Running`. The timeout is in seconds and defaults to the client
   timeout (`PROKUBE_TIMEOUT` / the `timeout` option, 300 by default). The whole
@@ -296,8 +303,8 @@ for (const sandbox of page.sandboxes) {
 }
 
 while (page.hasMore) {
-  // The continuation token is an opaque keyset cursor: pass it back with the
-  // same limit to fetch the next page.
+  // The continuation token is an opaque keyset cursor: pass it back together
+  // with a `limit` (required whenever a token is supplied) for the next page.
   page = await Sandbox.listPage({ limit: 10, continueToken: page.continueToken });
   for (const sandbox of page.sandboxes) {
     console.log(sandbox.name, sandbox.status);

--- a/README.md
+++ b/README.md
@@ -20,15 +20,25 @@ default, so installing from source can leave `dist/` missing unless the package
 is explicitly trusted.
 
 ```bash
-# Replace v2026-04-24 with the desired release tag
-bun add https://github.com/prokube/prokube-sdk-ts/releases/download/v2026-04-24/prokube-v2026-04-24.tgz
+# Replace v0.2.0 with the desired release tag
+bun add https://github.com/prokube/prokube-sdk-ts/releases/download/v0.2.0/prokube-v0.2.0.tgz
 ```
 
 Each GitHub release publishes a packed `.tgz` built from the SDK's `dist/`
 output, so consumers do not need to run `prepare` or rebuild inside Docker.
-This repo uses date-based package versions such as `2026.4.24`, with matching
-GitHub release tags and asset names such as `v2026-04-24` and
-`prokube-v2026-04-24.tgz`.
+
+### Versioning
+
+Starting with `0.2.0` this SDK uses semantic versioning, aligned with the
+Python SDK (`prokube-sdk`) release line. Earlier releases used date-based
+versions such as `2026.7.5` with release tags like `v2026-07-05`. Release tags
+are now `v` + the `package.json` version (for example `v0.2.0`), and release
+assets are named accordingly (`prokube-v0.2.0.tgz`).
+
+`0.2.0` requires a pk-sandbox backend of **0.8.0 or newer**. The SDK checks the
+backend version on first use and emits a `console.warn` when the backend is
+older than the minimum; the check is skipped for API-key (external) access
+because external endpoints do not expose `/api/version`.
 
 To validate the release package path locally, run:
 
@@ -41,8 +51,9 @@ npm run smoke:release
 ```typescript
 import { Sandbox } from "prokube";
 
-// Claim a sandbox from a warm pool (instant, <100ms)
+// Claim a sandbox from a warm pool (fast, but adoption is asynchronous)
 const sbx = await Sandbox.fromPool("python-pool");
+await sbx.waitUntilReady();
 
 // Or create directly (cold start, ~10-30s)
 const sbx2 = await Sandbox.create("pk-sandbox:python-datascience");
@@ -67,8 +78,14 @@ await sbx.files.writeBatch([
 const content = await sbx.files.read("/workspace/output.txt");
 const files = await sbx.files.list("/workspace");
 
-// Cleanup
-await sbx.kill();
+// Pause / resume: both are asynchronous on the backend.
+await sbx.pause(); // blocks until the sandbox reports Paused
+await sbx.resume(); // returns immediately, phase is Resuming
+await sbx.waitUntilReady(); // block until the new pod is Running
+
+// Cleanup. Deletion (including the persistence purge that releases the name)
+// is asynchronous; pass { wait: true } when you need guaranteed reclamation.
+await sbx.kill({ wait: true });
 ```
 
 ### Automatic Cleanup
@@ -80,6 +97,7 @@ import { Sandbox } from "prokube";
 
 {
   await using sbx = await Sandbox.fromPool("python-pool");
+  await sbx.waitUntilReady();
   const result = await sbx.runCode("print(42)");
   console.log(result.stdout);
 } // Sandbox is automatically killed
@@ -89,6 +107,7 @@ Or with a `try/finally` block:
 
 ```typescript
 const sbx = await Sandbox.fromPool("python-pool");
+await sbx.waitUntilReady();
 try {
   const result = await sbx.runCode("print(42)");
   console.log(result.stdout);
@@ -96,6 +115,12 @@ try {
   await sbx.kill();
 }
 ```
+
+`await using` and the `try/finally` block both call `kill()` with its default
+(non-blocking) behaviour: the delete request is accepted with HTTP 202 and the
+backend finishes tearing the sandbox down — including the persistence purge
+that releases the name — in the background. Use `kill({ wait: true })` when you
+need the name reclaimed before continuing.
 
 ## Configuration
 
@@ -192,27 +217,108 @@ The main class for interacting with sandboxes.
 class Sandbox {
   name: string;       // Sandbox name
   workspace: string;  // Workspace (Kubernetes namespace)
-  status: SandboxStatus; // Pending, Running, Paused, Bound, Succeeded, Failed, Unknown
+  status: SandboxStatus; // Pending, Running, Paused, Pausing, Resuming,
+                         // Deleting, Succeeded, Failed, Unknown
 
   static fromPool(pool: string, options?: SandboxOptions): Promise<Sandbox>;
   static create(image: string, options?: SandboxOptions & { name?: string }): Promise<Sandbox>;
   static get(name: string, options?: ConfigOptions): Promise<Sandbox>;
   static connect: typeof Sandbox.get;  // Alias
   static list(options?: ConfigOptions & { phase?: SandboxStatus }): Promise<Sandbox[]>;
+  static listPage(
+    options?: ConfigOptions & { limit?: number; continueToken?: string },
+  ): Promise<SandboxPage>;
 
   runCode(code: string, language?: string, timeout?: number): Promise<CodeResult>;
   resetSession(): void;
 
-  pause(): Promise<void>;
+  pause(options?: { wait?: boolean; timeout?: number }): Promise<void>;
   resume(): Promise<void>;
   waitUntilReady(timeout?: number): Promise<void>;
-  kill(): Promise<void>;
+  kill(options?: { wait?: boolean; timeout?: number }): Promise<void>;
 
   commands: CommandRunner;
   files: FileManager;
   sessionId: string | undefined;
 }
 ```
+
+#### Lifecycle
+
+Against a v0.8 backend every lifecycle transition is asynchronous: claim,
+create, pause, resume, and delete are accepted with HTTP 202 and the sandbox
+moves through an intermediate phase before it settles.
+
+| Call | Returns when | Phase you observe | Follow up with |
+| --- | --- | --- | --- |
+| `fromPool()` | claim accepted | `Pending` | `waitUntilReady()` |
+| `create()` | create accepted | `Pending` | `waitUntilReady()` |
+| `pause()` | sandbox reports `Paused` (default `wait: true`) | `Pausing` → `Paused` | — |
+| `pause({ wait: false })` | pause accepted | `Pausing` | poll `refresh()` / `status` |
+| `resume()` | resume accepted (never blocks) | `Resuming` | `waitUntilReady()` |
+| `kill()` | delete accepted (default `wait: false`) | `Deleting` | — |
+| `kill({ wait: true })` | sandbox is gone (HTTP 404) | `Deleting` → gone | — |
+
+- `pause(options)` defaults to `{ wait: true, timeout: 300 }` (seconds), so
+  existing `await sbx.pause()` call sites keep blocking until `Paused`.
+- `kill(options)` defaults to `{ wait: false, timeout: 300 }`. Deletion
+  includes an asynchronous persistence purge, and the sandbox name stays
+  reserved until that purge finishes — pass `{ wait: true }` when you need to
+  reuse the name or reclaim quota immediately.
+- `waitUntilReady(timeout)` polls through `Pending` and `Resuming` until the
+  phase is `Running`. The timeout is in seconds and defaults to the client
+  timeout (`PROKUBE_TIMEOUT` / the `timeout` option, 300 by default). The whole
+  poll shares one timeout budget, so a single slow status request cannot exceed
+  it. It throws `SandboxError` if the sandbox reaches `Failed` (the message
+  carries `lastError`) or `Deleting`, and `SandboxTimeoutError` on timeout.
+- `SandboxStatus.Bound` is deprecated: v0.8 backends never return it. It is
+  kept in the enum so existing code compiles.
+
+#### Pagination
+
+`listPage()` returns one bounded, name-ordered page across every sandbox
+phase. Idle warm-pool capacity is internal infrastructure and never appears in
+the listing. `limit` defaults to `25` and must be between 1 and 100.
+
+```typescript
+import { Sandbox } from "prokube";
+
+interface SandboxPage {
+  sandboxes: Sandbox[];
+  loaded: number;
+  hasMore: boolean;
+  continueToken?: string;
+}
+
+let page = await Sandbox.listPage({ limit: 10 });
+for (const sandbox of page.sandboxes) {
+  console.log(sandbox.name, sandbox.status);
+}
+
+while (page.hasMore) {
+  // The continuation token is an opaque keyset cursor: pass it back with the
+  // same limit to fetch the next page.
+  page = await Sandbox.listPage({ limit: 10, continueToken: page.continueToken });
+  for (const sandbox of page.sandboxes) {
+    console.log(sandbox.name, sandbox.status);
+  }
+}
+```
+
+`Sandbox.list()` is unchanged and still returns every sandbox in one call.
+
+#### Backend compatibility
+
+```typescript
+import { MIN_BACKEND_VERSION, getSdkVersion, parseVersion } from "prokube";
+
+console.log(MIN_BACKEND_VERSION); // "0.8.0"
+```
+
+Every `Sandbox.*` / `SandboxPool.*` factory checks the backend version once per
+client before its first request. A backend older than `MIN_BACKEND_VERSION`
+produces a `console.warn`; the check never throws and is skipped entirely for
+API-key (external) access, where `/api/version` is not exposed.
 
 ### CommandRunner
 
@@ -263,6 +369,24 @@ Execution timeouts are returned as failed results, not successful executions:
 so `commandSuccess(result)` returns `false`. Timeout details are included in the
 error fields or `stderr` when provided by the backend.
 
+### SandboxInfo
+
+```typescript
+interface SandboxInfo {
+  name: string;
+  workspace: string;
+  status: SandboxStatus;
+  lastError?: string;        // Backend failure detail, set when status is Failed
+  resumedFromPool?: boolean; // @deprecated - no longer populated by v0.8 backends
+  // ...remaining fields unchanged
+}
+```
+
+`lastError` carries the backend's failure detail for a sandbox in phase
+`Failed`. `pause()`, `kill({ wait: true })`, and `waitUntilReady()` include it
+in the `SandboxError` they throw when a sandbox fails mid-transition, so the
+reason surfaces instead of a bare timeout.
+
 ### Errors
 
 ```
@@ -282,6 +406,15 @@ HTTP 429 with `reason` or `error` set to `pool_exhausted`. Treat this as
 retryable backpressure: no warm pool capacity is currently available. The error
 has `statusCode: 429`, `reason: "pool_exhausted"`, and preserves the optional
 `Retry-After` response header as `retryAfter`.
+
+`kill({ wait: true })` rejects with `SandboxError` if the backend lands the
+delete in a terminal failure (phase `Failed`, message carries `lastError`), and
+with `SandboxTimeoutError` if the sandbox is still present when the timeout
+elapses. Once the delete has been admitted the sandbox is locked even if the
+wait fails: `runCode()`, `commands`, and `files` reject from then on, while
+`kill({ wait: true })` may be re-issued to keep waiting (the backend's DELETE is
+idempotent while teardown is in flight). If the initial delete request itself
+fails, the sandbox stays usable so you can retry.
 
 ## Development
 
@@ -310,6 +443,7 @@ npm run build
 
 - Node.js >= 20.19.0 (uses native `fetch`)
 - TypeScript >= 5.7
+- pk-sandbox backend >= 0.8.0
 
 ## License
 

--- a/docs/WARM_POOL_GUIDE.md
+++ b/docs/WARM_POOL_GUIDE.md
@@ -4,7 +4,7 @@ This guide walks through the typical workflow for using prokube.ai sandboxes wit
 
 ## Prerequisites
 
-- A prokube.ai cluster with sandbox support enabled
+- A prokube.ai cluster with sandbox support enabled (pk-sandbox backend >= 0.8.0)
 - An API key (create one in the UI under **Settings → API Keys**)
 - Node.js >= 20.19
 
@@ -35,7 +35,7 @@ npx tsx my-script.ts
 
 ## 1. Create a Warm Pool
 
-Warm pools keep pre-warmed sandboxes ready so you can claim one instantly instead of waiting for a cold start (~15-20s).
+Warm pools keep pre-warmed sandboxes ready so you can claim one in about a second instead of waiting for a cold start (~15-20s).
 
 You can create a pool in the prokube.ai UI, or via the SDK:
 
@@ -66,7 +66,52 @@ You only need to do this once. The pool stays running and automatically replenis
 import { Sandbox } from "prokube";
 
 const sbx = await Sandbox.fromPool("my-pool");
-// Ready to use — typically takes ~1s
+await sbx.waitUntilReady();
+```
+
+Claiming is fast, but the backend adopts the pre-warmed pod asynchronously: the
+claim is accepted with HTTP 202 and the sandbox starts out in phase `Pending`.
+Always `await sbx.waitUntilReady()` before running anything — it polls until
+the phase is `Running` (typically ~1s for a warm pool) and rejects with
+`SandboxError` if the sandbox reaches `Failed` (the message carries the
+backend's `lastError`).
+
+### Sandbox Phases
+
+`sbx.status` reports the sandbox phase. Against a v0.8 backend every lifecycle
+transition is asynchronous, so you will observe intermediate phases:
+
+| Phase | Meaning |
+| --- | --- |
+| `Pending` | Claimed or created, pod still starting |
+| `Running` | Ready for `runCode`, `commands`, and `files` |
+| `Pausing` | Pause accepted, workspace being flushed to S3 |
+| `Paused` | Pod terminated, workspace preserved |
+| `Resuming` | Resume accepted, new pod starting |
+| `Deleting` | Delete accepted, teardown and persistence purge in progress |
+| `Failed` | Terminal failure; see `lastError` |
+| `Succeeded` / `Unknown` | Finished / not reported by the backend |
+
+### Listing Sandboxes by Page
+
+`Sandbox.listPage()` returns one bounded, name-ordered page across every
+phase. The continuation token is an opaque keyset cursor — pass it back with
+the same `limit` to fetch the next page. `limit` defaults to `25` and must be
+between 1 and 100. Idle warm-pool capacity is internal infrastructure and never
+appears in the listing.
+
+```typescript
+import { Sandbox } from "prokube";
+
+let page = await Sandbox.listPage({ limit: 10 });
+while (true) {
+  for (const sandbox of page.sandboxes) {
+    console.log(`${sandbox.name}: ${sandbox.status}`);
+  }
+  console.log(`${page.loaded} on this page, hasMore=${page.hasMore}`);
+  if (!page.hasMore) break;
+  page = await Sandbox.listPage({ limit: 10, continueToken: page.continueToken });
+}
 ```
 
 ## 3. Run Code
@@ -159,23 +204,38 @@ with open('/workspace/data.csv') as f:
 
 ## 6. Pause & Resume
 
-Pause frees compute resources while preserving your workspace in S3. Resume brings the sandbox back with all files intact.
+Pause frees compute resources while preserving your workspace in S3. Resume brings the sandbox back with all files intact. Both transitions are asynchronous on the backend.
 
 ```typescript
 // Save some work
 await sbx.files.write("/workspace/checkpoint.pkl", modelData);
 
-// Pause — workspace is flushed to S3, pod is terminated
+// Pause — workspace is flushed to S3, pod is terminated.
+// Blocks until the sandbox reports Paused (default { wait: true, timeout: 300 }).
 await sbx.pause();
 // No compute costs while paused
 
-// Later: resume
+// Fire-and-forget variant: returns as soon as the backend accepted the
+// request, leaving the phase at Pausing.
+// await sbx.pause({ wait: false });
+
+// Later: resume. resume() never blocks — the phase goes to Resuming.
 await sbx.resume();
 await sbx.waitUntilReady();
 
 // Files are restored from S3
 const checkpoint = await sbx.files.read("/workspace/checkpoint.pkl");
 ```
+
+Pausing terminates the pod, so the Jupyter session is reset: the next
+`runCode()` after a pause or resume starts a fresh kernel.
+
+`pause()` rejects with `SandboxError` if the pause lands in phase `Failed` (the
+message carries the backend's `lastError`; re-issue `pause()` to retry) or if a
+concurrently admitted delete preempts it — delete outranks pause on the
+backend, so a sandbox that reaches `Deleting` will never reach `Paused`. It
+rejects with `SandboxTimeoutError` if the sandbox has not paused within the
+timeout.
 
 **What survives pause/resume:**
 - All files in `/workspace`, `/root`, and `/home/agent`
@@ -188,8 +248,14 @@ const checkpoint = await sbx.files.read("/workspace/checkpoint.pkl");
 ## 7. Clean Up
 
 ```typescript
-// Kill the sandbox when done
+// Kill the sandbox when done. The delete is accepted with HTTP 202 and the
+// backend tears the sandbox down — including the persistence purge that
+// releases the name — in the background.
 await sbx.kill();
+
+// Or block until the sandbox is really gone (needed if you want to reuse the
+// name or reclaim quota right away):
+// await sbx.kill({ wait: true });
 ```
 
 Or use automatic cleanup:
@@ -197,8 +263,9 @@ Or use automatic cleanup:
 ```typescript
 {
   await using sbx = await Sandbox.fromPool("my-pool");
+  await sbx.waitUntilReady();
   await sbx.runCode("print('hello')");
-} // automatically killed
+} // automatically killed (non-blocking)
 ```
 
 ## 8. Manage Pools
@@ -228,6 +295,7 @@ Putting it all together — a script that claims a sandbox, uploads data, proces
 import { Sandbox } from "prokube";
 
 const sbx = await Sandbox.fromPool("my-pool");
+await sbx.waitUntilReady();
 
 try {
   // Create data via code
@@ -254,7 +322,7 @@ print(f"Students: {len(data)}")
   // "Average score: 91.3"
   // "Students: 3"
 
-  // Pause to save costs
+  // Pause to save costs (blocks until the phase is Paused)
   await sbx.pause();
   console.log("Paused — no compute costs");
 
@@ -268,6 +336,7 @@ print(f"Students: {len(data)}")
   console.log(check.stdout);
 
 } finally {
-  await sbx.kill();
+  // Wait for the teardown so the sandbox name is reclaimed before we exit.
+  await sbx.kill({ wait: true });
 }
 ```

--- a/docs/WARM_POOL_GUIDE.md
+++ b/docs/WARM_POOL_GUIDE.md
@@ -95,10 +95,11 @@ transition is asynchronous, so you will observe intermediate phases:
 ### Listing Sandboxes by Page
 
 `Sandbox.listPage()` returns one bounded, name-ordered page across every
-phase. The continuation token is an opaque keyset cursor — pass it back with
-the same `limit` to fetch the next page. `limit` defaults to `25` and must be
-between 1 and 100. Idle warm-pool capacity is internal infrastructure and never
-appears in the listing.
+phase. The continuation token is an opaque keyset cursor — pass it back
+together with a `limit`, which the backend requires whenever a token is
+supplied. `limit` defaults to `25` and must be between 1 and 100. Idle
+warm-pool capacity is internal infrastructure and never appears in the
+listing.
 
 ```typescript
 import { Sandbox } from "prokube";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prokube",
-	"version": "2026.7.5",
+	"version": "0.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prokube",
-			"version": "2026.7.5",
+			"version": "0.2.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prokube",
-	"version": "2026.7.5",
+	"version": "0.2.0",
 	"description": "TypeScript SDK for the prokube.ai sandbox platform",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"smoke:release": "node ./scripts/smoke-release.mjs",
 		"test": "vitest run",
 		"test:watch": "vitest",
+		"test:e2e": "vitest run --config vitest.e2e.config.ts",
 		"lint": "biome check .",
 		"lint:fix": "biome check --write .",
 		"format": "biome format --write .",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -21,7 +21,7 @@ function resolvePackageBin(packageName, binName) {
 	const packageJson = require(packageJsonPath);
 	const binField = packageJson.bin;
 	const relativeBinPath =
-		typeof binField === "string" ? binField : binField?.[binName] ?? binField?.[packageName];
+		typeof binField === "string" ? binField : (binField?.[binName] ?? binField?.[packageName]);
 
 	if (!relativeBinPath) {
 		throw new Error(`Could not resolve binary ${binName} from ${packageName}.`);

--- a/scripts/check-dts-lib.mjs
+++ b/scripts/check-dts-lib.mjs
@@ -102,9 +102,7 @@ export function getDeclarationRoot(file, packageRoot = resolve(".")) {
 		relativeFile.startsWith(`..${sep}`) ||
 		relativeFile === ".."
 	) {
-		throw new Error(
-			`Cannot determine declaration root for ${file} relative to ${packageRoot}.`,
-		);
+		throw new Error(`Cannot determine declaration root for ${file} relative to ${packageRoot}.`);
 	}
 
 	if (!relativeFile.includes(sep)) {
@@ -126,9 +124,7 @@ export function validateDeclarationFile(file, declarationRoot = getDeclarationRo
 
 	for (const specifier of findRelativeSpecifiers(source)) {
 		const paths = getDeclarationCandidatePaths(baseDir, specifier);
-		const validPaths = [...new Set(paths)].filter((path) =>
-			isWithinRoot(path, declarationRoot),
-		);
+		const validPaths = [...new Set(paths)].filter((path) => isWithinRoot(path, declarationRoot));
 
 		if (!validPaths.some((path) => existsSync(path))) {
 			throw new Error(`Broken declaration import in ${file}: ${specifier}`);

--- a/scripts/check-dts.mjs
+++ b/scripts/check-dts.mjs
@@ -1,7 +1,4 @@
-import {
-	getDeclarationFilesFromPackageJson,
-	validateDeclarationFile,
-} from "./check-dts-lib.mjs";
+import { getDeclarationFilesFromPackageJson, validateDeclarationFile } from "./check-dts-lib.mjs";
 
 for (const file of getDeclarationFilesFromPackageJson()) {
 	validateDeclarationFile(file);

--- a/scripts/smoke-release.mjs
+++ b/scripts/smoke-release.mjs
@@ -1,43 +1,41 @@
+import { execFileSync } from "node:child_process";
 import { mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { execFileSync } from "node:child_process";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
 const artifactsDir = path.join(repoRoot, ".artifacts");
-const packageJson = JSON.parse(
-  readFileSync(path.join(repoRoot, "package.json"), "utf8"),
-);
+const packageJson = JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8"));
 const tarballName = `${packageJson.name}-${packageJson.version}.tgz`;
 const tarballPath = path.join(artifactsDir, tarballName);
 
 mkdirSync(artifactsDir, { recursive: true });
 
 execFileSync("npm", ["run", "pack:release"], {
-  cwd: repoRoot,
-  stdio: "inherit",
+	cwd: repoRoot,
+	stdio: "inherit",
 });
 
 execFileSync(
-  "docker",
-  [
-    "build",
-    "--no-cache",
-    "--build-arg",
-    `PACKAGE_TGZ=${path.relative(repoRoot, tarballPath)}`,
-    "-f",
-    path.join("tests", "smoke", "release-consumer", "Dockerfile"),
-    "-t",
-    `prokube-sdk-smoke:${Date.now()}`,
-    ".",
-  ],
-  {
-    cwd: repoRoot,
-    stdio: "inherit",
-    env: {
-      ...process.env,
-      DOCKER_BUILDKIT: process.env.DOCKER_BUILDKIT ?? "1",
-    },
-  },
+	"docker",
+	[
+		"build",
+		"--no-cache",
+		"--build-arg",
+		`PACKAGE_TGZ=${path.relative(repoRoot, tarballPath)}`,
+		"-f",
+		path.join("tests", "smoke", "release-consumer", "Dockerfile"),
+		"-t",
+		`prokube-sdk-smoke:${Date.now()}`,
+		".",
+	],
+	{
+		cwd: repoRoot,
+		stdio: "inherit",
+		env: {
+			...process.env,
+			DOCKER_BUILDKIT: process.env.DOCKER_BUILDKIT ?? "1",
+		},
+	},
 );

--- a/src/common/compat.ts
+++ b/src/common/compat.ts
@@ -1,0 +1,77 @@
+import type { HttpClient } from "./http.js";
+
+/**
+ * Minimum pk-sandbox backend version this SDK targets.
+ *
+ * v0.8 made every sandbox mutation admission-only (202 + full Sandbox body)
+ * and introduced the transitional phases `Pausing`, `Resuming` and
+ * `Deleting`, which this SDK's lifecycle waits depend on.
+ */
+export const MIN_BACKEND_VERSION = "0.8.0";
+
+/** Keep in sync with the `version` field in package.json. */
+const SDK_VERSION = "0.2.0";
+
+/** Get the current SDK version. */
+export function getSdkVersion(): string {
+	return SDK_VERSION;
+}
+
+/**
+ * Parse a version string into a normalized `[major, minor, patch]` tuple.
+ *
+ * Accepts `"1.2.3"`, `"v0.1"`, `"0.1.0-dev"`, `"1.2.3rc1"` and friends:
+ * a `v` prefix and any `-suffix`/`+build` are stripped, each component
+ * contributes its leading digits, and missing components default to 0.
+ */
+export function parseVersion(version: string): [number, number, number] {
+	const cleaned = version
+		.replace(/^[vV]+/, "")
+		.split("-")[0]
+		.split("+")[0];
+	const parts: number[] = [];
+	for (const part of cleaned.split(".")) {
+		const match = /^(\d+)/.exec(part);
+		if (match) parts.push(Number.parseInt(match[1], 10));
+	}
+	return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+}
+
+/**
+ * Warn when the backend is older than {@link MIN_BACKEND_VERSION}.
+ *
+ * Never throws: an unreachable or version-less backend is not a reason to
+ * fail the caller's actual operation, and a stale backend only degrades
+ * gracefully. The check is skipped for API-key (external) auth because the
+ * external routes do not expose `/api/version`.
+ */
+export async function checkBackendCompatibility(client: HttpClient): Promise<void> {
+	if (client.config.useApiKey) return;
+
+	try {
+		const response = await client.get("/api/version");
+		const version =
+			response && typeof response === "object" && "version" in response
+				? response.version
+				: undefined;
+		if (typeof version !== "string" || version === "" || version === "unknown") return;
+
+		const backend = parseVersion(version);
+		const minimum = parseVersion(MIN_BACKEND_VERSION);
+		const isOlder =
+			backend[0] !== minimum[0]
+				? backend[0] < minimum[0]
+				: backend[1] !== minimum[1]
+					? backend[1] < minimum[1]
+					: backend[2] < minimum[2];
+
+		if (isOlder) {
+			console.warn(
+				`Backend version ${version} may be incompatible with SDK version ${SDK_VERSION}. Minimum required backend version: ${MIN_BACKEND_VERSION}. Some features may not work correctly.`,
+			);
+		}
+	} catch {
+		// The backend may not have a version endpoint yet, or may be
+		// temporarily unreachable. Either way, don't block the caller.
+	}
+}

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -12,6 +12,22 @@ export class ProKubeError extends Error {
 }
 
 /**
+ * Raised when a single HTTP request exceeds its timeout budget.
+ *
+ * This is the transport-level timeout (the `AbortSignal` fired), distinct
+ * from {@link SandboxTimeoutError}, which reports that a whole lifecycle
+ * wait (`waitUntilReady`, `pause({ wait: true })`, `kill({ wait: true })`)
+ * ran out of time. Lifecycle polling loops swallow this error and retry
+ * until their own deadline expires.
+ */
+export class RequestTimeoutError extends ProKubeError {
+	constructor(message: string) {
+		super(message);
+		this.name = "RequestTimeoutError";
+	}
+}
+
+/**
  * Raised when authentication fails or credentials are missing.
  */
 export class AuthenticationError extends ProKubeError {

--- a/src/common/http.ts
+++ b/src/common/http.ts
@@ -1,6 +1,12 @@
 import { getAuthHeaders } from "./auth.js";
 import type { Config } from "./config.js";
-import { AuthenticationError, NotFoundError, PoolExhaustedError, ProKubeError } from "./errors.js";
+import {
+	AuthenticationError,
+	NotFoundError,
+	PoolExhaustedError,
+	ProKubeError,
+	RequestTimeoutError,
+} from "./errors.js";
 
 interface ErrorResponseBody {
 	detail?: unknown;
@@ -31,34 +37,47 @@ export class HttpClient {
 		}
 	}
 
-	async get(path: string, params?: Record<string, string>): Promise<unknown> {
-		return this.request("GET", path, undefined, params);
+	/**
+	 * @param timeout Per-request timeout override in seconds. Defaults to
+	 *   `config.timeout`. Callers polling toward a deadline (e.g.
+	 *   `waitUntilReady`) should pass the remaining budget so a single
+	 *   stalled request cannot outlast the caller's overall timeout.
+	 */
+	async get(path: string, params?: Record<string, string>, timeout?: number): Promise<unknown> {
+		return this.request("GET", path, undefined, params, timeout);
 	}
 
-	async post(path: string, body?: unknown): Promise<unknown> {
-		return this.request("POST", path, body);
+	/** @param timeout Per-request timeout override in seconds. See {@link get}. */
+	async post(path: string, body?: unknown, timeout?: number): Promise<unknown> {
+		return this.request("POST", path, body, undefined, timeout);
 	}
 
-	async delete(path: string): Promise<unknown | null> {
-		const url = this.buildUrl(path);
-		const response = await fetch(url, {
-			method: "DELETE",
-			headers: this.headers,
-		});
-		await this.handleError(response);
-		if (response.status === 204) return null;
-		const text = await response.text();
-		return text ? JSON.parse(text) : null;
+	/** @param timeout Per-request timeout override in seconds. See {@link get}. */
+	async delete(path: string, timeout?: number): Promise<unknown | null> {
+		return this.perform(
+			this.buildUrl(path),
+			{ method: "DELETE", headers: this.headers },
+			timeout,
+			async (response) => {
+				if (response.status === 204) return null;
+				const text = await response.text();
+				return text ? JSON.parse(text) : null;
+			},
+		);
 	}
 
-	async getBytes(path: string, params?: Record<string, string>): Promise<Uint8Array> {
-		const url = this.buildUrl(path, params);
-		const response = await fetch(url, {
-			method: "GET",
-			headers: this.headers,
-		});
-		await this.handleError(response);
-		return new Uint8Array(await response.arrayBuffer());
+	/** @param timeout Per-request timeout override in seconds. See {@link get}. */
+	async getBytes(
+		path: string,
+		params?: Record<string, string>,
+		timeout?: number,
+	): Promise<Uint8Array> {
+		return this.perform(
+			this.buildUrl(path, params),
+			{ method: "GET", headers: this.headers },
+			timeout,
+			async (response) => new Uint8Array(await response.arrayBuffer()),
+		);
 	}
 
 	close(): void {
@@ -71,16 +90,53 @@ export class HttpClient {
 		path: string,
 		body?: unknown,
 		params?: Record<string, string>,
+		timeout?: number,
 	): Promise<unknown> {
-		const url = this.buildUrl(path, params);
-		const response = await fetch(url, {
-			method,
-			headers: this.headers,
-			body: body != null ? JSON.stringify(body) : undefined,
-		});
-		await this.handleError(response);
-		const text = await response.text();
-		return text ? JSON.parse(text) : {};
+		return this.perform(
+			this.buildUrl(path, params),
+			{
+				method,
+				headers: this.headers,
+				body: body != null ? JSON.stringify(body) : undefined,
+			},
+			timeout,
+			async (response) => {
+				const text = await response.text();
+				return text ? JSON.parse(text) : {};
+			},
+		);
+	}
+
+	/**
+	 * Run one request under a timeout budget, then hand the response to
+	 * `consume`.
+	 *
+	 * The abort signal stays armed while the body is read, so a response that
+	 * stalls mid-stream is bounded too. Abort-by-timeout is normalized into
+	 * {@link RequestTimeoutError} so lifecycle polling loops can retry it
+	 * without swallowing genuine transport failures.
+	 */
+	private async perform<T>(
+		url: string,
+		init: RequestInit,
+		timeout: number | undefined,
+		consume: (response: Response) => Promise<T>,
+	): Promise<T> {
+		const seconds = timeout ?? this.config.timeout;
+		// AbortSignal.timeout takes milliseconds and rejects immediately at 0,
+		// so a sub-millisecond remaining budget is floored to 1ms rather than
+		// silently becoming "no timeout".
+		const signal = AbortSignal.timeout(Math.max(1, Math.ceil(seconds * 1000)));
+		try {
+			const response = await fetch(url, { ...init, signal });
+			await this.handleError(response);
+			return await consume(response);
+		} catch (error) {
+			if (isTimeoutAbort(error)) {
+				throw new RequestTimeoutError(`Request to ${url} timed out after ${seconds}s`);
+			}
+			throw error;
+		}
 	}
 
 	private buildUrl(path: string, params?: Record<string, string>): string {
@@ -134,6 +190,27 @@ export class HttpClient {
 		}
 		throw new ProKubeError(message, response.status);
 	}
+}
+
+/**
+ * Detect a fetch rejection caused by our own {@link AbortSignal.timeout}.
+ *
+ * Runtimes disagree on how the abort reason surfaces: undici rejects with the
+ * `TimeoutError` DOMException directly, others wrap it as an `AbortError` or
+ * bury it in `cause`. Walk a bounded slice of the cause chain to cover all
+ * three without risking a cycle.
+ */
+function isTimeoutAbort(error: unknown): boolean {
+	let current: unknown = error;
+	for (let depth = 0; current != null && depth < 5; depth++) {
+		if (typeof current !== "object") return false;
+		if ("name" in current) {
+			const name = current.name;
+			if (name === "TimeoutError" || name === "AbortError") return true;
+		}
+		current = "cause" in current ? current.cause : undefined;
+	}
+	return false;
 }
 
 function stringValue(value: unknown): string | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,13 @@ export {
 	Sandbox,
 	type SandboxOptions,
 	type SandboxCreateOptions,
+	type PauseOptions,
+	type KillOptions,
+	type SandboxListPageOptions,
+	type SandboxPage,
 } from "./sandbox/sandbox.js";
 export { SandboxPool, type CreatePoolOptions } from "./sandbox/pool.js";
-export { SandboxClient } from "./sandbox/client.js";
+export { SandboxClient, type ListPageOptions } from "./sandbox/client.js";
 export { PoolClient } from "./sandbox/pool-client.js";
 export { CodeRunner } from "./sandbox/code.js";
 export { CommandRunner } from "./sandbox/commands.js";
@@ -12,6 +16,7 @@ export { FileManager } from "./sandbox/files.js";
 export {
 	SandboxStatus,
 	type SandboxInfo,
+	type SandboxInfoPage,
 	type PoolInfo,
 	type CreateSandboxRequest,
 	type CreatePoolRequest,
@@ -27,6 +32,13 @@ export {
 	combinedOutput,
 } from "./sandbox/models.js";
 export { Config, type ConfigOptions } from "./common/config.js";
+export { HttpClient } from "./common/http.js";
+export {
+	MIN_BACKEND_VERSION,
+	checkBackendCompatibility,
+	getSdkVersion,
+	parseVersion,
+} from "./common/compat.js";
 export {
 	ProKubeError,
 	AuthenticationError,
@@ -34,6 +46,7 @@ export {
 	SandboxError,
 	SandboxNotFoundError,
 	SandboxTimeoutError,
+	RequestTimeoutError,
 	SandboxExecutionError,
 	PoolNotFoundError,
 	PoolExhaustedError,

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -299,11 +299,6 @@ export class SandboxClient {
 		}
 	}
 
-	/** @deprecated Use {@link resume}, which now returns the admission body. */
-	async resumeInfo(name: string): Promise<SandboxInfo> {
-		return this.resume(name);
-	}
-
 	// ---- Execution ----
 
 	// Both exec entry points bound the fetch by

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -191,10 +191,11 @@ export class SandboxClient {
 	 * List one bounded page of sandboxes.
 	 *
 	 * There is exactly one name-ordered listing across every sandbox state.
-	 * The continuation token is an opaque keyset cursor and must be reused
-	 * with the same limit that produced it. An empty token means "no token":
-	 * the backend rejects `continueToken=` with HTTP 422, so it is treated
-	 * the same as omitting it and requests the first page.
+	 * The continuation token is an opaque keyset cursor, and the backend
+	 * requires `limit` to be present whenever `continueToken` is supplied.
+	 * An empty token means "no token": the backend rejects `continueToken=`
+	 * with HTTP 422, so it is treated the same as omitting it and requests
+	 * the first page.
 	 */
 	async listPage(options: ListPageOptions = {}): Promise<SandboxInfoPage> {
 		const limit = options.limit ?? 25;
@@ -258,8 +259,20 @@ export class SandboxClient {
 	 * The backend accepts the request with HTTP 202 and reports phase
 	 * `Pausing` until its worker settles the sandbox on `Paused`; poll
 	 * {@link get} to observe the final phase.
+	 *
+	 * Use {@link pauseInfo} when you need the admission body.
 	 */
-	async pause(name: string): Promise<SandboxInfo> {
+	async pause(name: string): Promise<void> {
+		await this.pauseInfo(name);
+	}
+
+	/**
+	 * Pause a running sandbox and return the accepted admission body.
+	 *
+	 * Same request as {@link pause}; the phase in the returned
+	 * {@link SandboxInfo} is the transitional `Pausing`, not the settled one.
+	 */
+	async pauseInfo(name: string): Promise<SandboxInfo> {
 		try {
 			const data = (await this.http.post(this.sandboxSubPath(name, "pause"))) as Record<
 				string,
@@ -279,8 +292,20 @@ export class SandboxClient {
 	 *
 	 * The backend accepts the request with HTTP 202 and reports phase
 	 * `Resuming` until the new pod is up; poll {@link get} until `Running`.
+	 *
+	 * Use {@link resumeInfo} when you need the admission body.
 	 */
-	async resume(name: string): Promise<SandboxInfo> {
+	async resume(name: string): Promise<void> {
+		await this.resumeInfo(name);
+	}
+
+	/**
+	 * Resume a paused sandbox and return the accepted admission body.
+	 *
+	 * Same request as {@link resume}; the phase in the returned
+	 * {@link SandboxInfo} is the transitional `Resuming`.
+	 */
+	async resumeInfo(name: string): Promise<SandboxInfo> {
 		try {
 			const data = (await this.http.post(this.sandboxSubPath(name, "resume"))) as Record<
 				string,
@@ -295,15 +320,19 @@ export class SandboxClient {
 		}
 	}
 
-	/**
-	 * @deprecated {@link resume} now returns the same {@link SandboxInfo}.
-	 *   Kept so existing call sites keep compiling.
-	 */
-	async resumeInfo(name: string): Promise<SandboxInfo> {
-		return this.resume(name);
-	}
-
 	// ---- Execution ----
+
+	// Both exec entry points bound the fetch by
+	// `max(config.timeout, <execution timeout>)`. Python sends exec through
+	// the shared `httpx.Client`, built once with `timeout=self.config.timeout`
+	// (see `prokube/common/http.py`), and `SandboxClient.exec_code` /
+	// `exec_command` pass no per-request override — so the transport budget is
+	// the configured timeout, with no extra grace on top of the execution
+	// timeout. We keep that configured timeout as the floor (never shortening
+	// a request that used to be allowed) and raise it to the caller's
+	// execution budget when that is longer: otherwise
+	// `execCode(..., timeout: 600)` under the default 300s config would abort
+	// the fetch before the backend could answer.
 
 	async execCode(
 		name: string,
@@ -322,10 +351,11 @@ export class SandboxClient {
 		if (sessionId) body.session_id = sessionId;
 		if (resetSession) body.reset_session = true;
 
-		const data = (await this.http.post(this.sandboxSubPath(name, "exec"), body)) as Record<
-			string,
-			unknown
-		>;
+		const data = (await this.http.post(
+			this.sandboxSubPath(name, "exec"),
+			body,
+			Math.max(this.http.config.timeout, timeout),
+		)) as Record<string, unknown>;
 
 		return parseCodeResult(data);
 	}
@@ -337,10 +367,11 @@ export class SandboxClient {
 			timeout,
 		};
 
-		const data = (await this.http.post(this.sandboxSubPath(name, "exec"), body)) as Record<
-			string,
-			unknown
-		>;
+		const data = (await this.http.post(
+			this.sandboxSubPath(name, "exec"),
+			body,
+			Math.max(this.http.config.timeout, timeout),
+		)) as Record<string, unknown>;
 
 		return parseCommandResult(data);
 	}

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -1,3 +1,4 @@
+import { checkBackendCompatibility } from "../common/compat.js";
 import type { Config } from "../common/config.js";
 import {
 	NotFoundError,
@@ -16,24 +17,55 @@ import {
 	type FileInfo,
 	type FileWriteInput,
 	type SandboxInfo,
+	type SandboxInfoPage,
 	SandboxStatus,
 	parseBatchFileWriteResponse,
 	parseCodeResult,
 	parseCommandResult,
 	parseFileInfo,
 	parseSandboxInfo,
-	parseStatus,
 } from "./models.js";
 
 const textEncoder = new TextEncoder();
 
+/** Options for one page of {@link SandboxClient.listPage}. */
+export interface ListPageOptions {
+	/** Page size, 1–100 (default: 25). */
+	limit?: number;
+	/** Opaque keyset cursor from the previous page's `continueToken`. */
+	continueToken?: string;
+}
+
 export class SandboxClient {
 	private readonly http: HttpClient;
 	private readonly workspace: string;
+	private readonly checkVersion: boolean;
+	private compatibilityChecked: Promise<void> | undefined;
 
-	constructor(config: Config) {
+	/**
+	 * @param checkVersion Whether {@link ensureCompatibility} performs the
+	 *   backend version check. Pass `false` for the extra clients built per
+	 *   listing result, whose compatibility the listing client already
+	 *   verified.
+	 */
+	constructor(config: Config, checkVersion = true) {
 		this.http = new HttpClient(config);
 		this.workspace = config.workspace;
+		this.checkVersion = checkVersion;
+	}
+
+	/**
+	 * Verify backend compatibility once, before the first real request.
+	 *
+	 * The Python SDK does this in `SandboxClient.__init__`; TypeScript
+	 * constructors cannot await, so the `Sandbox` factories call this
+	 * explicitly. Resolves immediately (and only warns, never throws) when
+	 * the check is disabled, uses API-key auth, or has already run.
+	 */
+	async ensureCompatibility(): Promise<void> {
+		if (!this.checkVersion) return;
+		this.compatibilityChecked ??= checkBackendCompatibility(this.http);
+		return this.compatibilityChecked;
 	}
 
 	// ---- Path helpers ----
@@ -55,6 +87,13 @@ export class SandboxClient {
 
 	// ---- Sandbox lifecycle ----
 
+	/**
+	 * Claim a sandbox from a warm pool.
+	 *
+	 * The backend accepts the claim with HTTP 202 and adopts a warm pod
+	 * asynchronously, so the returned sandbox usually starts out `Pending`.
+	 * Poll {@link get} until it is `Running`.
+	 */
 	async claimFromPool(
 		pool: string,
 		volumeSize?: string,
@@ -66,20 +105,32 @@ export class SandboxClient {
 			body.autoIdleTimeoutSeconds = autoIdleTimeoutSeconds;
 		}
 
+		let data: Record<string, unknown>;
 		try {
-			const data = (await this.http.post(`${this.sandboxesPath()}/claim`, body)) as Record<
+			data = (await this.http.post(`${this.sandboxesPath()}/claim`, body)) as Record<
 				string,
 				unknown
 			>;
-			return parseSandboxInfo(data, this.workspace);
 		} catch (e) {
 			if (e instanceof NotFoundError) {
 				throw new PoolNotFoundError(`Pool '${pool}' not found`);
 			}
 			throw e;
 		}
+		const info = parseSandboxInfo(data, this.workspace, SandboxStatus.Pending);
+		return {
+			...info,
+			pool: info.pool ?? pool,
+			autoIdleTimeoutSeconds: info.autoIdleTimeoutSeconds ?? autoIdleTimeoutSeconds,
+		};
 	}
 
+	/**
+	 * Create a new sandbox.
+	 *
+	 * The backend accepts the request with HTTP 202; the sandbox starts out
+	 * `Pending`. Poll {@link get} until it is `Running`.
+	 */
 	async create(params: CreateSandboxRequest): Promise<SandboxInfo> {
 		const {
 			image,
@@ -110,8 +161,24 @@ export class SandboxClient {
 		if (envVars !== undefined) body.envVars = envVars;
 		if (secretRefs !== undefined) body.secretRefs = secretRefs;
 
+		// The backend has two create wire shapes: the internal route's
+		// CreateSandboxRequest nests cpu/memory under `resources` (and
+		// silently ignores the top-level keys), while the external API-key
+		// route's ExternalCreateRequest takes them flat (and ignores
+		// `resources`). Send both so sizing is never dropped; each route
+		// reads its own shape.
+		const resources: Record<string, string> = {};
+		if (cpu !== undefined) resources.cpu = cpu;
+		if (memory !== undefined) resources.memory = memory;
+		if (Object.keys(resources).length > 0) body.resources = resources;
+
 		const data = (await this.http.post(this.sandboxesPath(), body)) as Record<string, unknown>;
-		return parseSandboxInfo(data, this.workspace);
+		const info = parseSandboxInfo(data, this.workspace, SandboxStatus.Pending);
+		return {
+			...info,
+			image: info.image ?? image,
+			autoIdleTimeoutSeconds: info.autoIdleTimeoutSeconds ?? autoIdleTimeoutSeconds,
+		};
 	}
 
 	async list(): Promise<SandboxInfo[]> {
@@ -120,10 +187,49 @@ export class SandboxClient {
 		return sandboxes.map((s) => parseSandboxInfo(s, this.workspace));
 	}
 
-	async get(name: string): Promise<SandboxInfo> {
+	/**
+	 * List one bounded page of sandboxes.
+	 *
+	 * There is exactly one name-ordered listing across every sandbox state.
+	 * The continuation token is an opaque keyset cursor and must be reused
+	 * with the same limit that produced it. An empty token means "no token":
+	 * the backend rejects `continueToken=` with HTTP 422, so it is treated
+	 * the same as omitting it and requests the first page.
+	 */
+	async listPage(options: ListPageOptions = {}): Promise<SandboxInfoPage> {
+		const limit = options.limit ?? 25;
+		if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+			throw new RangeError("limit must be between 1 and 100");
+		}
+
+		const params: Record<string, string> = { limit: String(limit) };
+		if (options.continueToken) params.continueToken = options.continueToken;
+
+		const data = (await this.http.get(this.sandboxesPath(), params)) as Record<string, unknown>;
+		const sandboxes = (data.sandboxes ?? []) as Record<string, unknown>[];
+		const infos = sandboxes.map((s) => parseSandboxInfo(s, this.workspace));
+		return {
+			sandboxes: infos,
+			loaded: typeof data.loaded === "number" ? data.loaded : infos.length,
+			hasMore: data.hasMore === true,
+			continueToken: typeof data.continueToken === "string" ? data.continueToken : undefined,
+		};
+	}
+
+	/**
+	 * Get information about a sandbox. This is the poll target for every
+	 * asynchronous lifecycle operation.
+	 *
+	 * @param requestTimeout Per-request timeout override in seconds. Callers
+	 *   polling toward a deadline should pass the remaining budget so a single
+	 *   stalled request cannot outlast their overall timeout.
+	 */
+	async get(name: string, requestTimeout?: number): Promise<SandboxInfo> {
 		try {
-			const data = (await this.http.get(this.sandboxPath(name))) as Record<string, unknown>;
-			return parseSandboxInfo(data, this.workspace);
+			const data = (await this.http.get(this.sandboxPath(name), undefined, requestTimeout)) as
+				| Record<string, unknown>
+				| undefined;
+			return parseSandboxInfo(data ?? {}, this.workspace);
 		} catch (e) {
 			if (e instanceof NotFoundError) {
 				throw new SandboxNotFoundError(`Sandbox '${name}' not found`);
@@ -132,15 +238,34 @@ export class SandboxClient {
 		}
 	}
 
+	/**
+	 * Delete a sandbox.
+	 *
+	 * The backend accepts the request with HTTP 202 and an empty body, then
+	 * tears the sandbox down — including purging its persistence records —
+	 * asynchronously. Poll {@link get} until it throws
+	 * {@link SandboxNotFoundError} to know the name has been released.
+	 */
 	async delete(name: string): Promise<void> {
 		await this.http.delete(this.sandboxPath(name));
 	}
 
 	// ---- Pause / Resume ----
 
-	async pause(name: string): Promise<void> {
+	/**
+	 * Pause a running sandbox.
+	 *
+	 * The backend accepts the request with HTTP 202 and reports phase
+	 * `Pausing` until its worker settles the sandbox on `Paused`; poll
+	 * {@link get} to observe the final phase.
+	 */
+	async pause(name: string): Promise<SandboxInfo> {
 		try {
-			await this.http.post(this.sandboxSubPath(name, "pause"));
+			const data = (await this.http.post(this.sandboxSubPath(name, "pause"))) as Record<
+				string,
+				unknown
+			>;
+			return parseSandboxInfo(data, this.workspace, SandboxStatus.Pausing);
 		} catch (e) {
 			if (e instanceof ProKubeError && e.statusCode === 409) {
 				throw new SandboxError(`Cannot pause sandbox '${name}': not in Running state`, 409);
@@ -149,35 +274,33 @@ export class SandboxClient {
 		}
 	}
 
-	async resume(name: string): Promise<void> {
-		await this.resumeInfo(name);
-	}
-
-	async resumeInfo(name: string): Promise<SandboxInfo> {
+	/**
+	 * Resume a paused sandbox.
+	 *
+	 * The backend accepts the request with HTTP 202 and reports phase
+	 * `Resuming` until the new pod is up; poll {@link get} until `Running`.
+	 */
+	async resume(name: string): Promise<SandboxInfo> {
 		try {
 			const data = (await this.http.post(this.sandboxSubPath(name, "resume"))) as Record<
 				string,
 				unknown
 			>;
-			const responseName = (data.name ?? data.sandboxName) as string | undefined;
-			if (responseName) return parseSandboxInfo(data, this.workspace);
-			const responseStatus = (data.status ?? data.phase) as string | undefined;
-
-			return {
-				name,
-				workspace: this.workspace,
-				status: responseStatus ? parseStatus(responseStatus) : SandboxStatus.Running,
-				image: data.image as string | undefined,
-				pool: (data.poolName ?? data.pool) as string | undefined,
-				createdAt: (data.createdAt ?? data.created_at) as string | undefined,
-				resumedFromPool: data.resumedFromPool === true,
-			};
+			return parseSandboxInfo(data, this.workspace, SandboxStatus.Resuming);
 		} catch (e) {
 			if (e instanceof ProKubeError && e.statusCode === 409) {
 				throw new SandboxError(`Cannot resume sandbox '${name}': not in Paused state`, 409);
 			}
 			throw e;
 		}
+	}
+
+	/**
+	 * @deprecated {@link resume} now returns the same {@link SandboxInfo}.
+	 *   Kept so existing call sites keep compiling.
+	 */
+	async resumeInfo(name: string): Promise<SandboxInfo> {
+		return this.resume(name);
 	}
 
 	// ---- Execution ----

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -254,25 +254,14 @@ export class SandboxClient {
 	// ---- Pause / Resume ----
 
 	/**
-	 * Pause a running sandbox.
+	 * Pause a running sandbox and return the accepted admission body.
 	 *
 	 * The backend accepts the request with HTTP 202 and reports phase
 	 * `Pausing` until its worker settles the sandbox on `Paused`; poll
-	 * {@link get} to observe the final phase.
-	 *
-	 * Use {@link pauseInfo} when you need the admission body.
-	 */
-	async pause(name: string): Promise<void> {
-		await this.pauseInfo(name);
-	}
-
-	/**
-	 * Pause a running sandbox and return the accepted admission body.
-	 *
-	 * Same request as {@link pause}; the phase in the returned
+	 * {@link get} to observe the final phase. The phase in the returned
 	 * {@link SandboxInfo} is the transitional `Pausing`, not the settled one.
 	 */
-	async pauseInfo(name: string): Promise<SandboxInfo> {
+	async pause(name: string): Promise<SandboxInfo> {
 		try {
 			const data = (await this.http.post(this.sandboxSubPath(name, "pause"))) as Record<
 				string,
@@ -288,24 +277,14 @@ export class SandboxClient {
 	}
 
 	/**
-	 * Resume a paused sandbox.
+	 * Resume a paused sandbox and return the accepted admission body.
 	 *
 	 * The backend accepts the request with HTTP 202 and reports phase
 	 * `Resuming` until the new pod is up; poll {@link get} until `Running`.
-	 *
-	 * Use {@link resumeInfo} when you need the admission body.
+	 * The phase in the returned {@link SandboxInfo} is the transitional
+	 * `Resuming`.
 	 */
-	async resume(name: string): Promise<void> {
-		await this.resumeInfo(name);
-	}
-
-	/**
-	 * Resume a paused sandbox and return the accepted admission body.
-	 *
-	 * Same request as {@link resume}; the phase in the returned
-	 * {@link SandboxInfo} is the transitional `Resuming`.
-	 */
-	async resumeInfo(name: string): Promise<SandboxInfo> {
+	async resume(name: string): Promise<SandboxInfo> {
 		try {
 			const data = (await this.http.post(this.sandboxSubPath(name, "resume"))) as Record<
 				string,
@@ -318,6 +297,11 @@ export class SandboxClient {
 			}
 			throw e;
 		}
+	}
+
+	/** @deprecated Use {@link resume}, which now returns the admission body. */
+	async resumeInfo(name: string): Promise<SandboxInfo> {
+		return this.resume(name);
 	}
 
 	// ---- Execution ----

--- a/src/sandbox/code.ts
+++ b/src/sandbox/code.ts
@@ -6,13 +6,23 @@ export class CodeRunner {
 	private readonly sandboxName: string;
 	private sessionId: string | undefined;
 	private resetOnNextExec = false;
+	private readonly checkUsable: (() => void) | undefined;
 
-	constructor(client: SandboxClient, sandboxName: string) {
+	/**
+	 * @param checkUsable Optional callback invoked before every execution.
+	 *   {@link Sandbox} injects its killed/deletion-requested guard here so a
+	 *   runner cached before the sandbox went away cannot keep issuing work —
+	 *   mirroring the Python SDK's `CodeRunner(check_killed=...)`, which
+	 *   guards `run` only; session bookkeeping stays local and unguarded.
+	 */
+	constructor(client: SandboxClient, sandboxName: string, checkUsable?: () => void) {
 		this.client = client;
 		this.sandboxName = sandboxName;
+		this.checkUsable = checkUsable;
 	}
 
 	async run(code: string, language = "python", timeout = 300): Promise<CodeResult> {
+		this.checkUsable?.();
 		const resetSession = this.resetOnNextExec;
 
 		const result = await this.client.execCode(

--- a/src/sandbox/commands.ts
+++ b/src/sandbox/commands.ts
@@ -5,14 +5,28 @@ export class CommandRunner {
 	private readonly client: SandboxClient;
 	private readonly sandboxName: string;
 	private readonly defaultTimeout: number;
+	private readonly checkUsable: (() => void) | undefined;
 
-	constructor(client: SandboxClient, sandboxName: string, defaultTimeout = 300) {
+	/**
+	 * @param checkUsable Optional callback invoked before every operation.
+	 *   {@link Sandbox} injects its killed/deletion-requested guard here so a
+	 *   runner cached before the sandbox went away cannot keep issuing work —
+	 *   mirroring the Python SDK's `CommandRunner(check_killed=...)`.
+	 */
+	constructor(
+		client: SandboxClient,
+		sandboxName: string,
+		defaultTimeout = 300,
+		checkUsable?: () => void,
+	) {
 		this.client = client;
 		this.sandboxName = sandboxName;
 		this.defaultTimeout = defaultTimeout;
+		this.checkUsable = checkUsable;
 	}
 
 	async run(command: string, timeout?: number): Promise<CommandResult> {
+		this.checkUsable?.();
 		return this.client.execCommand(this.sandboxName, command, timeout ?? this.defaultTimeout);
 	}
 }

--- a/src/sandbox/files.ts
+++ b/src/sandbox/files.ts
@@ -6,26 +6,38 @@ const textEncoder = new TextEncoder();
 export class FileManager {
 	private readonly client: SandboxClient;
 	private readonly sandboxName: string;
+	private readonly checkUsable: (() => void) | undefined;
 
-	constructor(client: SandboxClient, sandboxName: string) {
+	/**
+	 * @param checkUsable Optional callback invoked before every operation.
+	 *   {@link Sandbox} injects its killed/deletion-requested guard here so a
+	 *   manager cached before the sandbox went away cannot keep issuing work —
+	 *   mirroring the Python SDK's `FileManager(check_killed=...)`.
+	 */
+	constructor(client: SandboxClient, sandboxName: string, checkUsable?: () => void) {
 		this.client = client;
 		this.sandboxName = sandboxName;
+		this.checkUsable = checkUsable;
 	}
 
 	async write(path: string, content: string | Uint8Array): Promise<void> {
+		this.checkUsable?.();
 		const bytes = typeof content === "string" ? textEncoder.encode(content) : content;
 		await this.client.writeFile(this.sandboxName, path, bytes);
 	}
 
 	async read(path: string): Promise<Uint8Array> {
+		this.checkUsable?.();
 		return this.client.readFile(this.sandboxName, path);
 	}
 
 	async writeBatch(items: FileWriteInput[]): Promise<BatchFileWriteResponse> {
+		this.checkUsable?.();
 		return this.client.writeFilesBatch(this.sandboxName, items);
 	}
 
 	async list(path = "/workspace"): Promise<FileInfo[]> {
+		this.checkUsable?.();
 		return this.client.listFiles(this.sandboxName, path);
 	}
 }

--- a/src/sandbox/models.ts
+++ b/src/sandbox/models.ts
@@ -1,7 +1,24 @@
+/**
+ * Lifecycle phase of a sandbox.
+ *
+ * Since pk-sandbox v0.8 every mutation is admission-only, so the
+ * transitional phases `Pausing`, `Resuming` and `Deleting` are observable
+ * between a request being accepted and the backend settling it.
+ */
 export enum SandboxStatus {
 	Pending = "Pending",
 	Running = "Running",
 	Paused = "Paused",
+	/** Pause accepted; the pod is being torn down. Settles on `Paused`. */
+	Pausing = "Pausing",
+	/** Resume accepted; a new pod is starting. Settles on `Running`. */
+	Resuming = "Resuming",
+	/** Delete accepted; teardown and persistence purge are in flight. */
+	Deleting = "Deleting",
+	/**
+	 * @deprecated Never returned by pk-sandbox v0.8 or later backends. Kept
+	 * so existing code that references it still compiles.
+	 */
 	Bound = "Bound",
 	Succeeded = "Succeeded",
 	Failed = "Failed",
@@ -16,7 +33,21 @@ export interface SandboxInfo {
 	pool?: string;
 	createdAt?: string;
 	autoIdleTimeoutSeconds?: number;
+	/** Why the last lifecycle step failed. Set when the phase is `Failed`. */
+	lastError?: string;
+	/**
+	 * @deprecated pk-sandbox v0.8 no longer reports warm-pool resume swaps,
+	 * so this is never populated. Kept for source compatibility.
+	 */
 	resumedFromPool?: boolean;
+}
+
+/** One bounded page of sandbox information, as returned by the API. */
+export interface SandboxInfoPage {
+	sandboxes: SandboxInfo[];
+	loaded: number;
+	hasMore: boolean;
+	continueToken?: string;
 }
 
 export interface CodeResult {
@@ -139,29 +170,69 @@ export interface BatchFileWriteRequest {
 
 // ---- Parsing helpers ----
 
-export function parseStatus(value: string | undefined): SandboxStatus {
-	if (!value) return SandboxStatus.Unknown;
+/**
+ * @param fallback Phase to assume when the body reports none. Admission-only
+ *   endpoints (claim/create/pause/resume) know the phase they just requested,
+ *   so they pass it instead of falling back to `Unknown`.
+ */
+export function parseStatus(
+	value: string | undefined,
+	fallback: SandboxStatus = SandboxStatus.Unknown,
+): SandboxStatus {
+	if (!value) return fallback;
 	const match = Object.values(SandboxStatus).find((s) => s === value);
 	return match ?? SandboxStatus.Unknown;
 }
 
-export function parseSandboxInfo(data: Record<string, unknown>, workspace: string): SandboxInfo {
-	const name = (data.sandboxName ?? data.name) as string | undefined;
+/**
+ * Build a {@link SandboxInfo} from one raw backend Sandbox body.
+ *
+ * Every sandbox endpoint returns this same shape, so list/get/create/claim/
+ * pause/resume all share this parser. The backend has used both camelCase and
+ * snake_case spellings and reports the phase as either `status` or `phase`;
+ * accept every spelling so the endpoints stay in sync.
+ */
+export function parseSandboxInfo(
+	data: Record<string, unknown>,
+	workspace: string,
+	defaultStatus: SandboxStatus = SandboxStatus.Unknown,
+): SandboxInfo {
+	const name = stringField(data, "name");
 	if (!name) {
 		throw new Error("Invalid API response: sandbox name is missing");
 	}
 	return {
 		name,
 		workspace,
-		status: parseStatus((data.status ?? data.phase) as string | undefined),
-		image: data.image as string | undefined,
-		pool: (data.poolName ?? data.pool) as string | undefined,
-		createdAt: (data.createdAt ?? data.created_at) as string | undefined,
-		autoIdleTimeoutSeconds: (data.autoIdleTimeoutSeconds ?? data.auto_idle_timeout_seconds) as
-			| number
-			| undefined,
-		resumedFromPool: data.resumedFromPool === true,
+		status: parseStatus(stringField(data, "status", "phase"), defaultStatus),
+		image: stringField(data, "image"),
+		pool: stringField(data, "poolName", "pool"),
+		createdAt: stringField(data, "createdAt", "created_at"),
+		autoIdleTimeoutSeconds: numberField(
+			data,
+			"autoIdleTimeoutSeconds",
+			"auto_idle_timeout_seconds",
+		),
+		lastError: stringField(data, "lastError", "last_error"),
 	};
+}
+
+/** First key present as a non-empty string, mirroring the backend's aliases. */
+function stringField(data: Record<string, unknown>, ...keys: string[]): string | undefined {
+	for (const key of keys) {
+		const value = data[key];
+		if (typeof value === "string" && value !== "") return value;
+	}
+	return undefined;
+}
+
+/** First key present as a real number; booleans and NaN are rejected. */
+function numberField(data: Record<string, unknown>, ...keys: string[]): number | undefined {
+	for (const key of keys) {
+		const value = data[key];
+		if (typeof value === "number" && Number.isFinite(value)) return value;
+	}
+	return undefined;
 }
 
 export function parseCodeResult(data: Record<string, unknown>): CodeResult {

--- a/src/sandbox/models.ts
+++ b/src/sandbox/models.ts
@@ -15,11 +15,6 @@ export enum SandboxStatus {
 	Resuming = "Resuming",
 	/** Delete accepted; teardown and persistence purge are in flight. */
 	Deleting = "Deleting",
-	/**
-	 * @deprecated Never returned by pk-sandbox v0.8 or later backends. Kept
-	 * so existing code that references it still compiles.
-	 */
-	Bound = "Bound",
 	Succeeded = "Succeeded",
 	Failed = "Failed",
 	Unknown = "Unknown",
@@ -35,11 +30,6 @@ export interface SandboxInfo {
 	autoIdleTimeoutSeconds?: number;
 	/** Why the last lifecycle step failed. Set when the phase is `Failed`. */
 	lastError?: string;
-	/**
-	 * @deprecated pk-sandbox v0.8 no longer reports warm-pool resume swaps,
-	 * so this is never populated. Kept for source compatibility.
-	 */
-	resumedFromPool?: boolean;
 }
 
 /** One bounded page of sandbox information, as returned by the API. */

--- a/src/sandbox/pool-client.ts
+++ b/src/sandbox/pool-client.ts
@@ -1,3 +1,4 @@
+import { checkBackendCompatibility } from "../common/compat.js";
 import type { Config } from "../common/config.js";
 import { NotFoundError, PoolNotFoundError } from "../common/errors.js";
 import { HttpClient } from "../common/http.js";
@@ -6,10 +7,29 @@ import { type CreatePoolRequest, type PoolInfo, parsePoolInfo } from "./models.j
 export class PoolClient {
 	private readonly http: HttpClient;
 	private readonly workspace: string;
+	private readonly checkVersion: boolean;
+	private compatibilityChecked: Promise<void> | undefined;
 
-	constructor(config: Config) {
+	/**
+	 * @param checkVersion Whether {@link ensureCompatibility} performs the
+	 *   backend version check. Pass `false` for the extra clients built per
+	 *   listing result, whose compatibility the listing client already
+	 *   verified.
+	 */
+	constructor(config: Config, checkVersion = true) {
 		this.http = new HttpClient(config);
 		this.workspace = config.workspace;
+		this.checkVersion = checkVersion;
+	}
+
+	/**
+	 * Verify backend compatibility once, before the first real request.
+	 * See {@link SandboxClient.ensureCompatibility}.
+	 */
+	async ensureCompatibility(): Promise<void> {
+		if (!this.checkVersion) return;
+		this.compatibilityChecked ??= checkBackendCompatibility(this.http);
+		return this.compatibilityChecked;
 	}
 
 	// ---- Path helpers ----

--- a/src/sandbox/pool.ts
+++ b/src/sandbox/pool.ts
@@ -57,6 +57,7 @@ export class SandboxPool {
 		const config = new Config(options);
 		const client = new PoolClient(config);
 		try {
+			await client.ensureCompatibility();
 			const info = await client.create({
 				name: options.name,
 				image: options.image,
@@ -88,8 +89,11 @@ export class SandboxPool {
 		const config = new Config(options);
 		const client = new PoolClient(config);
 		try {
+			await client.ensureCompatibility();
 			const infos = await client.list();
-			return infos.map((info) => new SandboxPool(info, new PoolClient(config)));
+			// Each pool gets its own client; the listing client already
+			// verified backend compatibility, so skip the repeat check.
+			return infos.map((info) => new SandboxPool(info, new PoolClient(config, false)));
 		} finally {
 			client.close();
 		}
@@ -102,6 +106,7 @@ export class SandboxPool {
 		const config = new Config(options);
 		const client = new PoolClient(config);
 		try {
+			await client.ensureCompatibility();
 			const info = await client.get(name);
 			return new SandboxPool(info, client);
 		} catch (e) {

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -132,9 +132,16 @@ export class Sandbox {
 		this._pool = pool;
 		this._autoIdleTimeoutSeconds = autoIdleTimeoutSeconds;
 		this._lastError = lastError;
-		this._code = new CodeRunner(client, name);
-		this._commands = new CommandRunner(client, name, timeout);
-		this._files = new FileManager(client, name);
+		// Bind the usability guard into every helper so the check runs on each
+		// operation, not just on the property access that handed the helper
+		// out. Mirrors the Python SDK, which injects `_check_not_killed` into
+		// CommandRunner/FileManager/CodeRunner.
+		const checkUsable = () => {
+			this.checkUsable();
+		};
+		this._code = new CodeRunner(client, name, checkUsable);
+		this._commands = new CommandRunner(client, name, timeout, checkUsable);
+		this._files = new FileManager(client, name, checkUsable);
 	}
 
 	// ---- Factory methods ----
@@ -265,8 +272,9 @@ export class Sandbox {
 	 * List one bounded page of sandboxes.
 	 *
 	 * One name-ordered listing covers every sandbox state. Pass
-	 * `continueToken` from the previous page together with the same `limit`
-	 * to fetch the next page; the token is an opaque keyset cursor.
+	 * `continueToken` from the previous page to fetch the next page; the
+	 * token is an opaque keyset cursor and `limit` must be supplied whenever
+	 * a `continueToken` is.
 	 *
 	 * `loaded` and `hasMore` describe the page the backend returned, so they
 	 * are unaffected by the client-side `phase` filter.
@@ -389,7 +397,7 @@ export class Sandbox {
 	 */
 	async pause(options: PauseOptions = {}): Promise<void> {
 		this.checkUsable();
-		const info = await this._client.pause(this._name);
+		const info = await this._client.pauseInfo(this._name);
 		this._status = info.status;
 		this._lastError = info.lastError;
 		// Pausing deletes the underlying pod, so any existing Jupyter session
@@ -462,7 +470,7 @@ export class Sandbox {
 	 */
 	async resume(): Promise<void> {
 		this.checkUsable();
-		const info = await this._client.resume(this._name);
+		const info = await this._client.resumeInfo(this._name);
 		this._status = info.status;
 		this._lastError = info.lastError;
 		if (info.image) this._image = info.image;

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -1,11 +1,31 @@
 import { randomUUID } from "node:crypto";
 import { Config, type ConfigOptions } from "../common/config.js";
-import { ProKubeError, SandboxError, SandboxTimeoutError } from "../common/errors.js";
+import {
+	NotFoundError,
+	ProKubeError,
+	RequestTimeoutError,
+	SandboxError,
+	SandboxNotFoundError,
+	SandboxTimeoutError,
+} from "../common/errors.js";
 import { SandboxClient } from "./client.js";
 import { CodeRunner } from "./code.js";
 import { CommandRunner } from "./commands.js";
 import { FileManager } from "./files.js";
-import { type CodeResult, type EnvVar, type ResourceRequests, SandboxStatus } from "./models.js";
+import {
+	type CodeResult,
+	type EnvVar,
+	type ResourceRequests,
+	type SandboxInfo,
+	type SandboxInfoPage,
+	SandboxStatus,
+} from "./models.js";
+
+/**
+ * Interval between lifecycle polls. Every wait in this class (readiness,
+ * pause, deletion) reuses it so their pacing cannot drift apart.
+ */
+const POLL_INTERVAL_MS = 2000;
 
 export interface SandboxOptions extends ConfigOptions {
 	volumeSize?: string;
@@ -32,6 +52,49 @@ export interface SandboxCreateOptions extends SandboxOptions {
 	secretRefs?: string[];
 }
 
+/** Options for {@link Sandbox.pause}. */
+export interface PauseOptions {
+	/**
+	 * Block until the sandbox has actually reached `Paused` (default: true).
+	 * Pass `false` to return as soon as the backend accepted the request,
+	 * leaving the phase at `Pausing`.
+	 */
+	wait?: boolean;
+	/** Maximum seconds to wait when `wait` is true (default: 300). */
+	timeout?: number;
+}
+
+/** Options for {@link Sandbox.kill}. */
+export interface KillOptions {
+	/** Poll until the sandbox is really gone (default: false). */
+	wait?: boolean;
+	/** Maximum seconds to wait when `wait` is true (default: 300). */
+	timeout?: number;
+}
+
+/** Options for {@link Sandbox.listPage}. */
+export interface SandboxListPageOptions extends ConfigOptions {
+	/** Page size, 1–100 (default: 25). */
+	limit?: number;
+	/** Opaque keyset cursor from the previous page's `continueToken`. */
+	continueToken?: string;
+	/** Client-side phase filter applied to the page that was fetched. */
+	phase?: SandboxStatus;
+}
+
+/**
+ * One bounded page of ready-to-use sandboxes.
+ *
+ * Pass `continueToken` back to {@link Sandbox.listPage} together with the
+ * same `limit` to fetch the next page.
+ */
+export interface SandboxPage {
+	sandboxes: Sandbox[];
+	loaded: number;
+	hasMore: boolean;
+	continueToken?: string;
+}
+
 export class Sandbox {
 	private readonly _name: string;
 	private readonly _workspace: string;
@@ -44,7 +107,8 @@ export class Sandbox {
 	private _pool: string | undefined;
 	private _autoIdleTimeoutSeconds: number | undefined;
 	private _killed = false;
-	private _skipNextWarmup = false;
+	private _deleteRequested = false;
+	private _lastError: string | undefined;
 
 	private readonly _timeout: number;
 
@@ -57,6 +121,7 @@ export class Sandbox {
 		image?: string,
 		pool?: string,
 		autoIdleTimeoutSeconds?: number,
+		lastError?: string,
 	) {
 		this._name = name;
 		this._workspace = workspace;
@@ -66,6 +131,7 @@ export class Sandbox {
 		this._image = image;
 		this._pool = pool;
 		this._autoIdleTimeoutSeconds = autoIdleTimeoutSeconds;
+		this._lastError = lastError;
 		this._code = new CodeRunner(client, name);
 		this._commands = new CommandRunner(client, name, timeout);
 		this._files = new FileManager(client, name);
@@ -74,13 +140,17 @@ export class Sandbox {
 	// ---- Factory methods ----
 
 	/**
-	 * Claim a pre-warmed sandbox from a warm pool.
-	 * Typically ready in <100ms.
+	 * Claim a sandbox from a warm pool.
+	 *
+	 * This is the fastest way to get a sandbox: the backend adopts a
+	 * pre-warmed pod, but does so asynchronously, so the claim starts out in
+	 * phase `Pending`. Call {@link waitUntilReady} before using it.
 	 */
 	static async fromPool(pool: string, options: SandboxOptions = {}): Promise<Sandbox> {
 		const config = new Config(options);
 		const client = new SandboxClient(config);
 		try {
+			await client.ensureCompatibility();
 			const info = await client.claimFromPool(
 				pool,
 				options.volumeSize,
@@ -95,6 +165,7 @@ export class Sandbox {
 				info.image,
 				pool,
 				info.autoIdleTimeoutSeconds ?? options.autoIdleTimeoutSeconds,
+				info.lastError,
 			);
 		} catch (e) {
 			client.close();
@@ -104,12 +175,16 @@ export class Sandbox {
 
 	/**
 	 * Create a new sandbox from a container image.
-	 * Cold start takes ~10-30 seconds; call `waitUntilReady()` before use.
+	 *
+	 * The backend accepts the request asynchronously, so the sandbox starts
+	 * out `Pending` and cold start takes ~10-30 seconds; call
+	 * {@link waitUntilReady} before use.
 	 */
 	static async create(image: string, options: SandboxCreateOptions = {}): Promise<Sandbox> {
 		const config = new Config(options);
 		const client = new SandboxClient(config);
 		try {
+			await client.ensureCompatibility();
 			const sandboxName = options.name ?? `sandbox-${randomHex(8)}`;
 			const info = await client.create({
 				image,
@@ -131,6 +206,7 @@ export class Sandbox {
 				image,
 				info.pool,
 				info.autoIdleTimeoutSeconds ?? options.autoIdleTimeoutSeconds,
+				info.lastError,
 			);
 		} catch (e) {
 			client.close();
@@ -145,6 +221,7 @@ export class Sandbox {
 		const config = new Config(options);
 		const client = new SandboxClient(config);
 		try {
+			await client.ensureCompatibility();
 			const info = await client.get(name);
 			return new Sandbox(
 				info.name,
@@ -155,6 +232,7 @@ export class Sandbox {
 				info.image,
 				info.pool,
 				info.autoIdleTimeoutSeconds,
+				info.lastError,
 			);
 		} catch (e) {
 			client.close();
@@ -172,25 +250,74 @@ export class Sandbox {
 		const config = new Config(options);
 		const client = new SandboxClient(config);
 		try {
+			await client.ensureCompatibility();
 			const infos = await client.list();
-			return infos
-				.filter((info) => !options.phase || info.status === options.phase)
-				.map(
-					(info) =>
-						new Sandbox(
-							info.name,
-							config.workspace,
-							new SandboxClient(config),
-							info.status,
-							config.timeout,
-							info.image,
-							info.pool,
-							info.autoIdleTimeoutSeconds,
-						),
-				);
+			return Sandbox.wrapInfos(
+				infos.filter((info) => !options.phase || info.status === options.phase),
+				config,
+			);
 		} finally {
 			client.close();
 		}
+	}
+
+	/**
+	 * List one bounded page of sandboxes.
+	 *
+	 * One name-ordered listing covers every sandbox state. Pass
+	 * `continueToken` from the previous page together with the same `limit`
+	 * to fetch the next page; the token is an opaque keyset cursor.
+	 *
+	 * `loaded` and `hasMore` describe the page the backend returned, so they
+	 * are unaffected by the client-side `phase` filter.
+	 */
+	static async listPage(options: SandboxListPageOptions = {}): Promise<SandboxPage> {
+		const config = new Config(options);
+		const client = new SandboxClient(config);
+		let page: SandboxInfoPage;
+		try {
+			await client.ensureCompatibility();
+			page = await client.listPage({
+				limit: options.limit,
+				continueToken: options.continueToken,
+			});
+		} finally {
+			client.close();
+		}
+
+		return {
+			sandboxes: Sandbox.wrapInfos(
+				page.sandboxes.filter((info) => !options.phase || info.status === options.phase),
+				config,
+			),
+			loaded: page.loaded,
+			hasMore: page.hasMore,
+			continueToken: page.continueToken,
+		};
+	}
+
+	/**
+	 * Build one Sandbox per listing result.
+	 *
+	 * Each sandbox gets its own client so that `kill()` on one does not
+	 * invalidate the others. The version check is skipped because the listing
+	 * client already verified compatibility.
+	 */
+	private static wrapInfos(infos: SandboxInfo[], config: Config): Sandbox[] {
+		return infos.map(
+			(info) =>
+				new Sandbox(
+					info.name,
+					config.workspace,
+					new SandboxClient(config, false),
+					info.status,
+					config.timeout,
+					info.image,
+					info.pool,
+					info.autoIdleTimeoutSeconds,
+					info.lastError,
+				),
+		);
 	}
 
 	// ---- Properties ----
@@ -215,12 +342,12 @@ export class Sandbox {
 	}
 
 	get commands(): CommandRunner {
-		this.checkNotKilled();
+		this.checkUsable();
 		return this._commands;
 	}
 
 	get files(): FileManager {
-		this.checkNotKilled();
+		this.checkUsable();
 		return this._files;
 	}
 
@@ -235,7 +362,7 @@ export class Sandbox {
 	// ---- Code execution ----
 
 	async runCode(code: string, language = "python", timeout?: number): Promise<CodeResult> {
-		this.checkNotKilled();
+		this.checkUsable();
 		return this._code.run(code, language, timeout ?? this._timeout);
 	}
 
@@ -245,50 +372,164 @@ export class Sandbox {
 
 	// ---- Lifecycle ----
 
-	async pause(): Promise<void> {
-		this.checkNotKilled();
-		await this._client.pause(this._name);
-		this._status = SandboxStatus.Paused;
+	/**
+	 * Pause the sandbox, freeing its compute resources.
+	 *
+	 * Preserves `/workspace` (working directory) and `/home/agent` (HOME,
+	 * `pip --user`, dotfiles). Lost: running processes, apt-installed system
+	 * packages, `/tmp`.
+	 *
+	 * The backend accepts the pause asynchronously (phase `Pausing`). By
+	 * default this blocks until the sandbox reports `Paused`.
+	 *
+	 * @throws SandboxError if the sandbox is not Running, or if the pause
+	 *   itself fails (phase `Failed`). Re-issuing `pause()` retries.
+	 * @throws SandboxTimeoutError if the sandbox does not reach `Paused`
+	 *   within `options.timeout` seconds.
+	 */
+	async pause(options: PauseOptions = {}): Promise<void> {
+		this.checkUsable();
+		const info = await this._client.pause(this._name);
+		this._status = info.status;
+		this._lastError = info.lastError;
+		// Pausing deletes the underlying pod, so any existing Jupyter session
+		// is no longer valid. Reset so the next runCode() starts a fresh kernel.
 		this._code.markSessionInvalid();
+		if (options.wait ?? true) {
+			await this.waitForPause(options.timeout ?? 300);
+		}
 	}
 
+	/** Poll until the sandbox settles on Paused, Failed, or the deadline. */
+	private async waitForPause(timeout: number): Promise<void> {
+		const deadline = Date.now() + timeout * 1000;
+
+		while (true) {
+			let remainingMs = deadline - Date.now();
+			if (remainingMs <= 0) break;
+			try {
+				await this.refresh(remainingMs / 1000);
+			} catch (e) {
+				if (e instanceof SandboxNotFoundError || e instanceof NotFoundError) {
+					// A concurrently admitted delete finished while we waited.
+					throw new SandboxError(
+						`Sandbox '${this._name}' was deleted while waiting for it to pause`,
+					);
+				}
+				if (!(e instanceof RequestTimeoutError)) throw e;
+				// A single stalled poll is not fatal; retry until our deadline.
+			}
+
+			if (this._status === SandboxStatus.Paused) return;
+			if (this._status === SandboxStatus.Failed) {
+				throw new SandboxError(
+					`Sandbox '${this._name}' failed to pause: ${
+						this._lastError ?? "no error reported by the backend"
+					} (re-issue pause() to retry)`,
+				);
+			}
+			if (this._status === SandboxStatus.Deleting) {
+				// Delete outranks pause on the backend: the pause worker's
+				// settle will miss and the sandbox is going away. Waiting any
+				// longer can only end in 404.
+				throw new SandboxError(
+					`Sandbox '${this._name}' is being deleted; it will never reach Paused`,
+				);
+			}
+
+			remainingMs = deadline - Date.now();
+			if (remainingMs <= 0) break;
+			await sleep(Math.min(POLL_INTERVAL_MS, remainingMs));
+		}
+
+		throw new SandboxTimeoutError(
+			`Sandbox '${this._name}' did not pause within ${timeout}s (current phase: ${this._status})`,
+		);
+	}
+
+	/**
+	 * Resume a paused sandbox.
+	 *
+	 * A new pod starts with the same PVC mounts at `/workspace` and
+	 * `/home/agent`. If `/home/agent/.sandbox-restore.sh` exists, it runs
+	 * automatically on startup to reinstall system packages.
+	 *
+	 * The backend accepts the resume asynchronously and reports phase
+	 * `Resuming`; this call does not block. Use {@link waitUntilReady} to
+	 * wait for the new pod to become `Running`.
+	 *
+	 * @throws SandboxError if the sandbox is not in the `Paused` state.
+	 */
 	async resume(): Promise<void> {
-		this.checkNotKilled();
-		const info = await this._client.resumeInfo(this._name);
+		this.checkUsable();
+		const info = await this._client.resume(this._name);
 		this._status = info.status;
+		this._lastError = info.lastError;
 		if (info.image) this._image = info.image;
 		if (info.pool) this._pool = info.pool;
 		if (info.autoIdleTimeoutSeconds !== undefined) {
 			this._autoIdleTimeoutSeconds = info.autoIdleTimeoutSeconds;
 		}
-		this._skipNextWarmup = info.resumedFromPool === true;
+		// New pod means the previous Jupyter session is invalid.
 		this._code.markSessionInvalid();
 	}
 
+	/**
+	 * Block until the sandbox phase is `Running`. Useful after `resume()`.
+	 *
+	 * Transitional phases (`Pending`, `Pausing`, `Resuming`) simply keep
+	 * polling.
+	 *
+	 * @param timeout Maximum seconds to wait. Defaults to the configured
+	 *   request timeout.
+	 * @throws SandboxTimeoutError if the sandbox does not become `Running` in
+	 *   time.
+	 * @throws SandboxError if the sandbox enters a state from which it can no
+	 *   longer become ready (`Failed`, `Succeeded` or `Deleting`). For a
+	 *   failed sandbox the backend's `lastError` is included.
+	 */
 	async waitUntilReady(timeout?: number): Promise<void> {
+		this.checkUsable();
 		const effectiveTimeout = timeout ?? this._timeout;
 		const deadline = Date.now() + effectiveTimeout * 1000;
-		const pollIntervalMs = 2000;
 
-		while (Date.now() < deadline) {
-			await this.refresh();
+		while (true) {
+			let remainingMs = deadline - Date.now();
+			if (remainingMs <= 0) break;
+			try {
+				// Cap the GET at the remaining budget so a single stalled poll
+				// cannot block past the caller's deadline: without this the
+				// request falls back to the client's default timeout
+				// (PROKUBE_TIMEOUT, 300s), which can vastly exceed a short
+				// waitUntilReady(timeout) call.
+				await this.refresh(remainingMs / 1000);
+			} catch (e) {
+				if (!(e instanceof RequestTimeoutError)) throw e;
+				remainingMs = deadline - Date.now();
+				if (remainingMs <= 0) break;
+				await sleep(Math.min(POLL_INTERVAL_MS, remainingMs));
+				continue;
+			}
 
 			if (this._status === SandboxStatus.Running) {
-				if (this._skipNextWarmup) {
-					this._skipNextWarmup = false;
-					return;
-				}
 				await this.warmupKernel(deadline);
 				return;
 			}
 
-			if (this._status === SandboxStatus.Failed || this._status === SandboxStatus.Succeeded) {
-				throw new SandboxError(`Sandbox '${this._name}' entered terminal state: ${this._status}`);
+			if (
+				this._status === SandboxStatus.Failed ||
+				this._status === SandboxStatus.Succeeded ||
+				this._status === SandboxStatus.Deleting
+			) {
+				const detail = this._lastError ? `: ${this._lastError}` : "";
+				throw new SandboxError(
+					`Sandbox '${this._name}' entered terminal state ${this._status} while waiting for it to become ready${detail}`,
+				);
 			}
 
-			const remainingMs = deadline - Date.now();
+			remainingMs = deadline - Date.now();
 			if (remainingMs <= 0) break;
-			await sleep(Math.min(pollIntervalMs, remainingMs));
+			await sleep(Math.min(POLL_INTERVAL_MS, remainingMs));
 		}
 
 		throw new SandboxTimeoutError(
@@ -308,7 +549,7 @@ export class Sandbox {
 	 * other errors from `runCode` still propagate.
 	 */
 	private async warmupKernel(deadline: number): Promise<void> {
-		this.checkNotKilled();
+		this.checkUsable();
 		const marker = `__pk_warmup_${randomUUID().replace(/-/g, "")}__`;
 		const probeCode = `print("${marker}")`;
 		const probeIntervalMs = 500;
@@ -329,12 +570,11 @@ export class Sandbox {
 			if (remainingMs < minProbeBudgetMs) break;
 
 			// `probeTimeoutSec` caps the BACKEND execution time of the probe
-			// (passed through to /exec). It does NOT bound the client-side
-			// fetch() duration — HttpClient currently has no AbortSignal
-			// timeout, so a stalled TCP connection could still let a single
-			// probe overrun the overall waitUntilReady deadline. Tracked as
-			// a separate concern (HTTP-layer fetch timeout). floor() at
-			// least guarantees probeTimeoutSec * 1000 <= remainingMs.
+			// (passed through to /exec). The client-side fetch is bounded
+			// separately by the HTTP client's configured timeout, so a stalled
+			// connection can still let one probe outlive this deadline — that
+			// bound is config.timeout, not infinity. floor() at least
+			// guarantees probeTimeoutSec * 1000 <= remainingMs.
 			const probeTimeoutSec = Math.min(maxProbeTimeoutSec, Math.floor(remainingMs / 1000));
 			let result: CodeResult;
 			try {
@@ -362,18 +602,101 @@ export class Sandbox {
 		);
 	}
 
-	async kill(): Promise<void> {
+	/**
+	 * Destroy the sandbox.
+	 *
+	 * The backend accepts the delete with HTTP 202 and tears the sandbox down
+	 * asynchronously, including purging its persistence records. The sandbox
+	 * name stays reserved until that purge completes, so pass `wait: true`
+	 * when you intend to reuse the name (or need the quota back) and must
+	 * know the reclamation finished.
+	 *
+	 * Once the delete has been admitted the sandbox cannot be used anymore:
+	 * `runCode()`, `commands` and `files` throw. If waiting fails or times
+	 * out, the object stays in a deletion-requested state — normal operations
+	 * stay blocked, but `kill({ wait: true })` may be re-issued to keep
+	 * waiting (the backend's DELETE is idempotent while teardown is in
+	 * flight). If the initial delete request itself fails, the error is
+	 * thrown and the sandbox remains usable so callers can retry.
+	 *
+	 * @throws SandboxError if `wait` is true and the backend lands the delete
+	 *   in a terminal failure (phase `Failed` with `lastError`); re-issue
+	 *   `kill()` to retry the delete.
+	 * @throws SandboxTimeoutError if `wait` is true and the sandbox is still
+	 *   present after `options.timeout` seconds.
+	 */
+	async kill(options: KillOptions = {}): Promise<void> {
 		if (this._killed) return;
-		await this._client.delete(this._name);
+		try {
+			await this._client.delete(this._name);
+		} catch (e) {
+			if (!(e instanceof SandboxNotFoundError) && !(e instanceof NotFoundError)) throw e;
+			// A re-issued kill can find the sandbox already gone: that is the
+			// outcome we wanted, not an error.
+			this._status = SandboxStatus.Succeeded;
+			this._killed = true;
+			this._client.close();
+			return;
+		}
+		// The delete is admitted: from here the sandbox is going away and must
+		// not accept work, even if the wait below fails or times out.
+		this._deleteRequested = true;
+		if (options.wait ?? false) {
+			await this.waitUntilGone(options.timeout ?? 300);
+		}
 		this._status = SandboxStatus.Succeeded;
 		this._killed = true;
 		this._client.close();
 	}
 
-	async refresh(): Promise<void> {
-		this.checkNotKilled();
-		const info = await this._client.get(this._name);
+	/** Poll the sandbox until the backend reports it as absent (404). */
+	private async waitUntilGone(timeout: number): Promise<void> {
+		const deadline = Date.now() + timeout * 1000;
+
+		while (true) {
+			let remainingMs = deadline - Date.now();
+			if (remainingMs <= 0) break;
+			try {
+				const info = await this._client.get(this._name, remainingMs / 1000);
+				this._status = info.status;
+				this._lastError = info.lastError;
+				if (this._status === SandboxStatus.Failed) {
+					// delete_failed on the backend: retries are exhausted and
+					// the row (and name) stay reserved until a delete is
+					// re-issued and succeeds.
+					throw new SandboxError(
+						`Sandbox '${this._name}' failed to delete: ${
+							this._lastError ?? "no error reported by the backend"
+						} (re-issue kill() to retry)`,
+					);
+				}
+			} catch (e) {
+				if (e instanceof SandboxNotFoundError || e instanceof NotFoundError) return;
+				if (!(e instanceof RequestTimeoutError)) throw e;
+				// A single stalled poll is not fatal; retry until our deadline.
+			}
+
+			remainingMs = deadline - Date.now();
+			if (remainingMs <= 0) break;
+			await sleep(Math.min(POLL_INTERVAL_MS, remainingMs));
+		}
+
+		throw new SandboxTimeoutError(
+			`Sandbox '${this._name}' was not deleted within ${timeout}s (current phase: ${this._status})`,
+		);
+	}
+
+	/**
+	 * Refresh sandbox information from the API.
+	 *
+	 * @param requestTimeout Per-request timeout override in seconds. Callers
+	 *   polling toward a deadline should pass the remaining budget.
+	 */
+	async refresh(requestTimeout?: number): Promise<void> {
+		this.checkUsable();
+		const info = await this._client.get(this._name, requestTimeout);
 		this._status = info.status;
+		this._lastError = info.lastError;
 		if (info.image) this._image = info.image;
 		if (info.pool) this._pool = info.pool;
 		if (info.autoIdleTimeoutSeconds !== undefined) {
@@ -397,9 +720,21 @@ export class Sandbox {
 
 	// ---- Internal ----
 
-	private checkNotKilled(): void {
+	/**
+	 * Reject work on a sandbox that is killed or on its way out.
+	 *
+	 * A sandbox whose delete has been admitted is locked even though the
+	 * teardown may still be in flight: the pod is going away, so any exec or
+	 * file operation would either fail or silently target a doomed pod.
+	 */
+	private checkUsable(): void {
 		if (this._killed) {
 			throw new SandboxError(`Sandbox '${this._name}' has been killed and cannot be used anymore`);
+		}
+		if (this._deleteRequested) {
+			throw new SandboxError(
+				`Sandbox '${this._name}' is being deleted; call kill({ wait: true }) to wait for the deletion to complete`,
+			);
 		}
 	}
 }

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -85,8 +85,8 @@ export interface SandboxListPageOptions extends ConfigOptions {
 /**
  * One bounded page of ready-to-use sandboxes.
  *
- * Pass `continueToken` back to {@link Sandbox.listPage} together with the
- * same `limit` to fetch the next page.
+ * Pass `continueToken` back to {@link Sandbox.listPage} together with a
+ * `limit` (any valid value, 1-100) to fetch the next page.
  */
 export interface SandboxPage {
 	sandboxes: Sandbox[];

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -397,7 +397,7 @@ export class Sandbox {
 	 */
 	async pause(options: PauseOptions = {}): Promise<void> {
 		this.checkUsable();
-		const info = await this._client.pauseInfo(this._name);
+		const info = await this._client.pause(this._name);
 		this._status = info.status;
 		this._lastError = info.lastError;
 		// Pausing deletes the underlying pod, so any existing Jupyter session
@@ -470,7 +470,7 @@ export class Sandbox {
 	 */
 	async resume(): Promise<void> {
 		this.checkUsable();
-		const info = await this._client.resumeInfo(this._name);
+		const info = await this._client.resume(this._name);
 		this._status = info.status;
 		this._lastError = info.lastError;
 		if (info.image) this._image = info.image;

--- a/tests/api-surface.test.ts
+++ b/tests/api-surface.test.ts
@@ -55,7 +55,6 @@ describe("public API surface", () => {
 				"Pending",
 				"Running",
 				"Paused",
-				"Bound",
 				"Succeeded",
 				"Failed",
 				"Unknown",
@@ -95,13 +94,12 @@ describe("public API surface", () => {
 			// `pause/resume -> SandboxInfo` change in its 0.2.0 release:
 			// callers that only `await` are unaffected; wrappers annotated as
 			// `Promise<void>` must drop the annotation or ignore the body.
-			const pauseInfo: (name: string) => Promise<sdk.SandboxInfo> = client.pause.bind(client);
-			const resumeInfo: (name: string) => Promise<sdk.SandboxInfo> = client.resume.bind(client);
-			expect((await pauseInfo("sb-1")).name).toBe("sb-1");
-			expect((await resumeInfo("sb-1")).name).toBe("sb-1");
-
-			// Pre-0.8 deprecated alias survives.
-			expect((await client.resumeInfo("sb-1")).name).toBe("sb-1");
+			const pauseSig: (name: string) => Promise<sdk.SandboxInfo> = client.pause.bind(client);
+			const resumeSig: (name: string) => Promise<sdk.SandboxInfo> = client.resume.bind(client);
+			expect((await pauseSig("sb-1")).name).toBe("sb-1");
+			expect((await resumeSig("sb-1")).name).toBe("sb-1");
+			// The pre-0.8 resumeInfo alias is gone in 0.2.0, like in Python.
+			expect("resumeInfo" in client).toBe(false);
 		} finally {
 			vi.unstubAllGlobals();
 		}

--- a/tests/api-surface.test.ts
+++ b/tests/api-surface.test.ts
@@ -72,7 +72,7 @@ describe("public API surface", () => {
 		}
 	});
 
-	it("keeps SandboxClient.pause/resume resolving to void, with *Info for the body", async () => {
+	it("SandboxClient.pause/resume return the admission body (Python parity; typed-void wrappers must migrate)", async () => {
 		const fetchMock = vi.fn(
 			async () =>
 				new Response(JSON.stringify({ name: "sb-1", phase: "Pausing" }), {
@@ -91,16 +91,16 @@ describe("public API surface", () => {
 				false,
 			);
 
-			// Type-level pin: these signatures fail to compile if the return
-			// type widens away from Promise<void>, which is what pre-0.8 call
-			// sites were written against.
-			const pause: (name: string) => Promise<void> = client.pause.bind(client);
-			const resume: (name: string) => Promise<void> = client.resume.bind(client);
-			expect(await pause("sb-1")).toBeUndefined();
-			expect(await resume("sb-1")).toBeUndefined();
+			// v0.8 deliberate break, mirroring the Python SDK's
+			// `pause/resume -> SandboxInfo` change in its 0.2.0 release:
+			// callers that only `await` are unaffected; wrappers annotated as
+			// `Promise<void>` must drop the annotation or ignore the body.
+			const pauseInfo: (name: string) => Promise<sdk.SandboxInfo> = client.pause.bind(client);
+			const resumeInfo: (name: string) => Promise<sdk.SandboxInfo> = client.resume.bind(client);
+			expect((await pauseInfo("sb-1")).name).toBe("sb-1");
+			expect((await resumeInfo("sb-1")).name).toBe("sb-1");
 
-			// The admission bodies live on the *Info variants.
-			expect((await client.pauseInfo("sb-1")).name).toBe("sb-1");
+			// Pre-0.8 deprecated alias survives.
 			expect((await client.resumeInfo("sb-1")).name).toBe("sb-1");
 		} finally {
 			vi.unstubAllGlobals();

--- a/tests/api-surface.test.ts
+++ b/tests/api-surface.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import * as sdk from "../src/index.js";
+
+/**
+ * The v0.8 adaptation is a breaking change on the wire, not in the SDK's
+ * TypeScript surface: every symbol that existed before must still be exported
+ * and still behave. These tests fail loudly if a rename or removal slips in.
+ */
+describe("public API surface", () => {
+	it("still exports every pre-0.8 runtime value", () => {
+		for (const name of [
+			"Sandbox",
+			"SandboxPool",
+			"SandboxClient",
+			"PoolClient",
+			"CodeRunner",
+			"CommandRunner",
+			"FileManager",
+			"SandboxStatus",
+			"Config",
+			"commandSuccess",
+			"combinedOutput",
+			"ProKubeError",
+			"AuthenticationError",
+			"NotFoundError",
+			"SandboxError",
+			"SandboxNotFoundError",
+			"SandboxTimeoutError",
+			"SandboxExecutionError",
+			"PoolNotFoundError",
+			"PoolExhaustedError",
+		]) {
+			expect(sdk, `missing pre-0.8 export ${name}`).toHaveProperty(name);
+		}
+	});
+
+	it("exports the new v0.8 values", () => {
+		expect(sdk.MIN_BACKEND_VERSION).toBe("0.8.0");
+		expect(typeof sdk.parseVersion).toBe("function");
+		expect(typeof sdk.checkBackendCompatibility).toBe("function");
+		expect(typeof sdk.getSdkVersion).toBe("function");
+		expect(typeof sdk.RequestTimeoutError).toBe("function");
+		expect(typeof sdk.HttpClient).toBe("function");
+	});
+
+	it("keeps RequestTimeoutError inside the ProKubeError hierarchy", () => {
+		const error = new sdk.RequestTimeoutError("stalled");
+		expect(error).toBeInstanceOf(sdk.ProKubeError);
+		expect(error.name).toBe("RequestTimeoutError");
+	});
+
+	it("keeps every pre-0.8 SandboxStatus member and adds the transitional ones", () => {
+		expect(Object.values(sdk.SandboxStatus)).toEqual(
+			expect.arrayContaining([
+				"Pending",
+				"Running",
+				"Paused",
+				"Bound",
+				"Succeeded",
+				"Failed",
+				"Unknown",
+				"Pausing",
+				"Resuming",
+				"Deleting",
+			]),
+		);
+	});
+
+	it("keeps the Sandbox statics that existing call sites use", () => {
+		for (const name of ["fromPool", "create", "get", "connect", "list", "listPage"]) {
+			expect(typeof (sdk.Sandbox as unknown as Record<string, unknown>)[name]).toBe("function");
+		}
+	});
+
+	it("reports the SDK version the compatibility warning quotes", () => {
+		expect(sdk.getSdkVersion()).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+});

--- a/tests/api-surface.test.ts
+++ b/tests/api-surface.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import * as sdk from "../src/index.js";
 
 /**
@@ -70,6 +70,50 @@ describe("public API surface", () => {
 		for (const name of ["fromPool", "create", "get", "connect", "list", "listPage"]) {
 			expect(typeof (sdk.Sandbox as unknown as Record<string, unknown>)[name]).toBe("function");
 		}
+	});
+
+	it("keeps SandboxClient.pause/resume resolving to void, with *Info for the body", async () => {
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ name: "sb-1", phase: "Pausing" }), {
+					status: 202,
+					headers: { "content-type": "application/json" },
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		try {
+			const client = new sdk.SandboxClient(
+				new sdk.Config({
+					apiUrl: "https://example.com",
+					workspace: "ws",
+					userId: "user@test.com",
+				}),
+				false,
+			);
+
+			// Type-level pin: these signatures fail to compile if the return
+			// type widens away from Promise<void>, which is what pre-0.8 call
+			// sites were written against.
+			const pause: (name: string) => Promise<void> = client.pause.bind(client);
+			const resume: (name: string) => Promise<void> = client.resume.bind(client);
+			expect(await pause("sb-1")).toBeUndefined();
+			expect(await resume("sb-1")).toBeUndefined();
+
+			// The admission bodies live on the *Info variants.
+			expect((await client.pauseInfo("sb-1")).name).toBe("sb-1");
+			expect((await client.resumeInfo("sb-1")).name).toBe("sb-1");
+		} finally {
+			vi.unstubAllGlobals();
+		}
+	});
+
+	it("keeps Sandbox.pause/resume/kill resolving to void", () => {
+		// Type-level pin: assigning the method to a void-returning signature
+		// fails to compile if the return type widens.
+		const pause: (options?: sdk.PauseOptions) => Promise<void> = sdk.Sandbox.prototype.pause;
+		const resume: () => Promise<void> = sdk.Sandbox.prototype.resume;
+		const kill: (options?: sdk.KillOptions) => Promise<void> = sdk.Sandbox.prototype.kill;
+		expect([pause, resume, kill].every((fn) => typeof fn === "function")).toBe(true);
 	});
 
 	it("reports the SDK version the compatibility warning quotes", () => {

--- a/tests/api-surface.test.ts
+++ b/tests/api-surface.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import * as sdk from "../src/index.js";
 
 /**
- * The v0.8 adaptation is a breaking change on the wire, not in the SDK's
- * TypeScript surface: every symbol that existed before must still be exported
- * and still behave. These tests fail loudly if a rename or removal slips in.
+ * The 0.2.0 surface contract: everything the SDK supports stays exported and
+ * behaving, and the three maintainer-approved pre-0.8 removals (see PR #40
+ * comments 5218339682 / 5218412469) stay removed — `SandboxStatus.Bound`,
+ * `SandboxInfo.resumedFromPool`, and `SandboxClient.resumeInfo()`, matching
+ * the Python SDK 0.2.0. These tests fail loudly if a symbol is renamed,
+ * dropped, or a removed one sneaks back.
  */
 describe("public API surface", () => {
 	it("still exports every pre-0.8 runtime value", () => {
@@ -49,9 +52,9 @@ describe("public API surface", () => {
 		expect(error.name).toBe("RequestTimeoutError");
 	});
 
-	it("keeps every pre-0.8 SandboxStatus member and adds the transitional ones", () => {
-		expect(Object.values(sdk.SandboxStatus)).toEqual(
-			expect.arrayContaining([
+	it("carries the supported SandboxStatus members and not the retired Bound", () => {
+		expect(Object.values(sdk.SandboxStatus).sort()).toEqual(
+			[
 				"Pending",
 				"Running",
 				"Paused",
@@ -61,7 +64,7 @@ describe("public API surface", () => {
 				"Pausing",
 				"Resuming",
 				"Deleting",
-			]),
+			].sort(),
 		);
 	});
 

--- a/tests/check-dts.test.ts
+++ b/tests/check-dts.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -33,11 +33,7 @@ describe("check-dts helpers", () => {
 			type Baz = import("../baz.js").Baz;
 		`;
 
-		expect(findRelativeSpecifiers(source)).toEqual([
-			"./foo.js",
-			"./bar.js",
-			"../baz.js",
-		]);
+		expect(findRelativeSpecifiers(source)).toEqual(["./foo.js", "./bar.js", "../baz.js"]);
 	});
 
 	it("accepts runtime extensions that map to declaration files", () => {
@@ -54,10 +50,7 @@ describe("check-dts helpers", () => {
 		const dir = createTempDir();
 		const declarationFile = join(dir, "index.d.ts");
 
-		writeFileSync(
-			declarationFile,
-			'type Foo = import("./types.js").Foo;\nimport "./setup.js";\n',
-		);
+		writeFileSync(declarationFile, 'type Foo = import("./types.js").Foo;\nimport "./setup.js";\n');
 		writeFileSync(join(dir, "types.d.ts"), "export interface Foo {}\n");
 		writeFileSync(join(dir, "setup.d.ts"), "export {}\n");
 

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -472,17 +472,6 @@ describe("SandboxClient", () => {
 			expect((await client.resume("sb-1")).lastError).toBe("pvc restore failed");
 		});
 
-		it("resumeInfo stays as a deprecated alias for resume", async () => {
-			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", phase: "Resuming" }, 202));
-
-			const client = new SandboxClient(makeConfig());
-			const info = await client.resumeInfo("sb-1");
-
-			expect(mockFetch.mock.calls[0][0] as string).toContain("/sandboxes/sb-1/resume");
-			expect(info.status).toBe(SandboxStatus.Resuming);
-		});
-
 		it("pause throws SandboxError on 409", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ detail: "Not running" }, 409));

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -3,8 +3,11 @@ import { Config } from "../src/common/config.js";
 import { PoolExhaustedError, SandboxError } from "../src/common/errors.js";
 import { SandboxClient } from "../src/sandbox/client.js";
 import { SandboxStatus } from "../src/sandbox/models.js";
+import { captureRequestTimeouts } from "./helpers.js";
 
-function makeConfig(overrides: Partial<{ apiKey: string; userId: string }> = {}): Config {
+function makeConfig(
+	overrides: Partial<{ apiKey: string; userId: string; timeout: number }> = {},
+): Config {
 	return new Config({
 		apiUrl: "https://example.com/pkui",
 		workspace: "test-ns",
@@ -419,64 +422,77 @@ describe("SandboxClient", () => {
 	});
 
 	describe("pause/resume", () => {
-		it("pause sends POST to /pause and returns the accepted Sandbox body", async () => {
+		it("pause sends POST to /pause and resolves with undefined", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
 
 			const client = new SandboxClient(makeConfig());
-			const info = await client.pause("sb-1");
+			const result = await client.pause("sb-1");
+
+			expect(mockFetch.mock.calls[0][0] as string).toContain("/sandboxes/sb-1/pause");
+			// Pre-0.8 userspace signature: Promise<void>, not the admission body.
+			expect(result).toBeUndefined();
+		});
+
+		it("pauseInfo returns the accepted Sandbox body", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
+
+			const client = new SandboxClient(makeConfig());
+			const info = await client.pauseInfo("sb-1");
 
 			expect(mockFetch.mock.calls[0][0] as string).toContain("/sandboxes/sb-1/pause");
 			expect(info.name).toBe("sb-1");
 			expect(info.status).toBe(SandboxStatus.Pausing);
 		});
 
-		it("pause defaults to Pausing when the body omits the phase", async () => {
+		it("pauseInfo defaults to Pausing when the body omits the phase", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1" }, 202));
 
 			const client = new SandboxClient(makeConfig());
-			expect((await client.pause("sb-1")).status).toBe(SandboxStatus.Pausing);
+			expect((await client.pauseInfo("sb-1")).status).toBe(SandboxStatus.Pausing);
 		});
 
-		it("resume sends POST to /resume and returns the accepted Sandbox body", async () => {
+		it("resume sends POST to /resume and resolves with undefined", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", phase: "Resuming" }, 202));
 
 			const client = new SandboxClient(makeConfig());
-			const info = await client.resume("sb-1");
+			const result = await client.resume("sb-1");
 
 			expect(mockFetch.mock.calls[0][0] as string).toContain("/sandboxes/sb-1/resume");
-			expect(info.status).toBe(SandboxStatus.Resuming);
+			expect(result).toBeUndefined();
 		});
 
-		it("resume defaults to Resuming when the body omits the phase", async () => {
-			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1" }, 202));
-
-			const client = new SandboxClient(makeConfig());
-			expect((await client.resume("sb-1")).status).toBe(SandboxStatus.Resuming);
-		});
-
-		it("resume carries lastError through", async () => {
-			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(
-				mockResponse({ name: "sb-1", phase: "Failed", lastError: "pvc restore failed" }, 202),
-			);
-
-			const client = new SandboxClient(makeConfig());
-			expect((await client.resume("sb-1")).lastError).toBe("pvc restore failed");
-		});
-
-		it("resumeInfo stays available as an alias for resume", async () => {
+		it("resumeInfo returns the accepted Sandbox body", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", phase: "Resuming" }, 202));
 
 			const client = new SandboxClient(makeConfig());
 			const info = await client.resumeInfo("sb-1");
 
+			expect(mockFetch.mock.calls[0][0] as string).toContain("/sandboxes/sb-1/resume");
 			expect(info.name).toBe("sb-1");
 			expect(info.status).toBe(SandboxStatus.Resuming);
+		});
+
+		it("resumeInfo defaults to Resuming when the body omits the phase", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1" }, 202));
+
+			const client = new SandboxClient(makeConfig());
+			expect((await client.resumeInfo("sb-1")).status).toBe(SandboxStatus.Resuming);
+		});
+
+		it("resumeInfo carries lastError through", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(
+				mockResponse({ name: "sb-1", phase: "Failed", lastError: "pvc restore failed" }, 202),
+			);
+
+			const client = new SandboxClient(makeConfig());
+			expect((await client.resumeInfo("sb-1")).lastError).toBe("pvc restore failed");
 		});
 
 		it("pause throws SandboxError on 409", async () => {
@@ -487,12 +503,28 @@ describe("SandboxClient", () => {
 			await expect(client.pause("sb-1")).rejects.toThrow(SandboxError);
 		});
 
+		it("pauseInfo throws SandboxError on 409", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ detail: "Not running" }, 409));
+
+			const client = new SandboxClient(makeConfig());
+			await expect(client.pauseInfo("sb-1")).rejects.toThrow(SandboxError);
+		});
+
 		it("resume throws SandboxError on 409", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ detail: "Not paused" }, 409));
 
 			const client = new SandboxClient(makeConfig());
 			await expect(client.resume("sb-1")).rejects.toThrow(SandboxError);
+		});
+
+		it("resumeInfo throws SandboxError on 409", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ detail: "Not paused" }, 409));
+
+			const client = new SandboxClient(makeConfig());
+			await expect(client.resumeInfo("sb-1")).rejects.toThrow(SandboxError);
 		});
 	});
 
@@ -543,6 +575,52 @@ describe("SandboxClient", () => {
 
 			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
 			expect(body.use_jupyter).toBe(false);
+		});
+	});
+
+	describe("exec transport budget", () => {
+		const execBody = { stdout: "", stderr: "", success: true, durationMs: 1, exitCode: 0 };
+
+		it("gives execCode a fetch budget equal to an execution timeout above config.timeout", async () => {
+			vi.mocked(fetch).mockResolvedValue(mockResponse(execBody));
+			const budgets = captureRequestTimeouts();
+
+			const client = new SandboxClient(makeConfig({ timeout: 30 }));
+			await client.execCode("sb-1", "sleep(600)", "python", 600);
+
+			expect(budgets).toEqual([600_000]);
+		});
+
+		it("gives execCommand a fetch budget equal to an execution timeout above config.timeout", async () => {
+			vi.mocked(fetch).mockResolvedValue(mockResponse(execBody));
+			const budgets = captureRequestTimeouts();
+
+			const client = new SandboxClient(makeConfig({ timeout: 30 }));
+			await client.execCommand("sb-1", "sleep 600", 600);
+
+			expect(budgets).toEqual([600_000]);
+		});
+
+		it("keeps config.timeout as the floor for short execution timeouts", async () => {
+			vi.mocked(fetch).mockResolvedValue(mockResponse(execBody));
+			const budgets = captureRequestTimeouts();
+
+			const client = new SandboxClient(makeConfig({ timeout: 300 }));
+			await client.execCode("sb-1", "print(1)", "python", 5);
+
+			// A 5s backend execution budget must not shorten the transport
+			// budget below what every other request gets.
+			expect(budgets).toEqual([300_000]);
+		});
+
+		it("leaves non-exec requests on the configured budget", async () => {
+			vi.mocked(fetch).mockResolvedValue(mockResponse({ name: "sb-1", phase: "Running" }));
+			const budgets = captureRequestTimeouts();
+
+			const client = new SandboxClient(makeConfig({ timeout: 30 }));
+			await client.get("sb-1");
+
+			expect(budgets).toEqual([30_000]);
 		});
 	});
 

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -130,6 +130,43 @@ describe("SandboxClient", () => {
 				expect(poolError.retryAfter).toBe("15");
 			}
 		});
+
+		it("parses the v0.8 claim body like every other Sandbox response", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(
+				mockResponse(
+					{
+						name: "claim-abc",
+						namespace: "test-ns",
+						phase: "Pending",
+						poolName: "python-pool",
+						claimName: "claim-abc-claim",
+						lastError: null,
+					},
+					202,
+				),
+			);
+
+			const client = new SandboxClient(makeConfig());
+			const info = await client.claimFromPool("python-pool");
+
+			expect(info.name).toBe("claim-abc");
+			expect(info.workspace).toBe("test-ns");
+			expect(info.status).toBe(SandboxStatus.Pending);
+			expect(info.pool).toBe("python-pool");
+			expect(info.lastError).toBeUndefined();
+		});
+
+		it("defaults a phase-less claim body to Pending", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ name: "claim-abc" }, 202));
+
+			const client = new SandboxClient(makeConfig());
+			const info = await client.claimFromPool("python-pool");
+
+			expect(info.status).toBe(SandboxStatus.Pending);
+			expect(info.pool).toBe("python-pool");
+		});
 	});
 
 	describe("create", () => {
@@ -215,6 +252,44 @@ describe("SandboxClient", () => {
 			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
 			expect(body.allowInternetAccess).toBe(false);
 		});
+
+		it("sends resources in both wire shapes so sizing is never dropped", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ name: "my-sb", status: "Pending" }));
+
+			const client = new SandboxClient(makeConfig());
+			await client.create({ image: "python:3.10", cpu: "2", memory: "4Gi" });
+
+			// The internal route reads the nested `resources` object and ignores
+			// the flat keys; the external API-key route does the opposite.
+			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			expect(body.cpu).toBe("2");
+			expect(body.memory).toBe("4Gi");
+			expect(body.resources).toEqual({ cpu: "2", memory: "4Gi" });
+		});
+
+		it("sends a partial resources object when only one dimension is set", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ name: "my-sb", status: "Pending" }));
+
+			const client = new SandboxClient(makeConfig());
+			await client.create({ image: "python:3.10", memory: "8Gi" });
+
+			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			expect(body.resources).toEqual({ memory: "8Gi" });
+			expect(body).not.toHaveProperty("cpu");
+		});
+
+		it("omits resources entirely when neither cpu nor memory is set", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ name: "my-sb", status: "Pending" }));
+
+			const client = new SandboxClient(makeConfig());
+			await client.create({ image: "python:3.10" });
+
+			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			expect(body).not.toHaveProperty("resources");
+		});
 	});
 
 	describe("list", () => {
@@ -250,65 +325,158 @@ describe("SandboxClient", () => {
 		});
 	});
 
+	describe("listPage", () => {
+		it("preserves pagination metadata and echoes the requested token", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(
+				mockResponse({
+					sandboxes: [{ name: "paused-1", phase: "Paused" }],
+					loaded: 1,
+					hasMore: true,
+					continueToken: "next-token",
+				}),
+			);
+
+			const client = new SandboxClient(makeConfig());
+			const page = await client.listPage({ limit: 10, continueToken: "opaque-token" });
+
+			const url = new URL(mockFetch.mock.calls[0][0] as string);
+			expect(url.pathname).toBe("/pkui/_platform/sandbox/test-ns/sandboxes");
+			expect(Object.fromEntries(url.searchParams)).toEqual({
+				limit: "10",
+				continueToken: "opaque-token",
+			});
+			expect(page.sandboxes[0].status).toBe(SandboxStatus.Paused);
+			expect(page.loaded).toBe(1);
+			expect(page.hasMore).toBe(true);
+			expect(page.continueToken).toBe("next-token");
+		});
+
+		it("derives loaded and hasMore from a legacy listing body", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(
+				mockResponse({ sandboxes: [{ name: "sb-1", phase: "Running" }], total: 1 }),
+			);
+
+			const client = new SandboxClient(makeConfig());
+			const page = await client.listPage();
+
+			expect(page.loaded).toBe(1);
+			expect(page.hasMore).toBe(false);
+			expect(page.continueToken).toBeUndefined();
+		});
+
+		it("never sends an empty continuation token", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ sandboxes: [], loaded: 0, hasMore: false }));
+
+			const client = new SandboxClient(makeConfig());
+			await client.listPage({ continueToken: "" });
+
+			const url = new URL(mockFetch.mock.calls[0][0] as string);
+			expect(Object.fromEntries(url.searchParams)).toEqual({ limit: "25" });
+		});
+
+		it.each([0, 101])("rejects limit %i without issuing a request", async (limit) => {
+			const mockFetch = vi.mocked(fetch);
+			const client = new SandboxClient(makeConfig());
+
+			await expect(client.listPage({ limit })).rejects.toThrow(RangeError);
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("ensureCompatibility", () => {
+		it("probes /api/version at most once per client", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ version: "0.8.0" }));
+
+			const client = new SandboxClient(makeConfig());
+			await client.ensureCompatibility();
+			await client.ensureCompatibility();
+
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+			expect(mockFetch.mock.calls[0][0] as string).toBe("https://example.com/pkui/api/version");
+		});
+
+		it("does nothing when the client opted out of the check", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ version: "0.1.0" }));
+
+			await new SandboxClient(makeConfig(), false).ensureCompatibility();
+
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+
+		it("does nothing under API key auth, where /api/version does not exist", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ version: "0.1.0" }));
+
+			await new SandboxClient(makeConfig({ apiKey: "key-123" })).ensureCompatibility();
+
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+	});
+
 	describe("pause/resume", () => {
-		it("pause sends POST to /pause", async () => {
+		it("pause sends POST to /pause and returns the accepted Sandbox body", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({}));
+			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
 
 			const client = new SandboxClient(makeConfig());
-			await client.pause("sb-1");
+			const info = await client.pause("sb-1");
 
-			const url = mockFetch.mock.calls[0][0] as string;
-			expect(url).toContain("/sandboxes/sb-1/pause");
+			expect(mockFetch.mock.calls[0][0] as string).toContain("/sandboxes/sb-1/pause");
+			expect(info.name).toBe("sb-1");
+			expect(info.status).toBe(SandboxStatus.Pausing);
 		});
 
-		it("resume sends POST to /resume", async () => {
+		it("pause defaults to Pausing when the body omits the phase", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({}));
+			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1" }, 202));
 
 			const client = new SandboxClient(makeConfig());
-			await expect(client.resume("sb-1")).resolves.toBeUndefined();
-
-			const url = mockFetch.mock.calls[0][0] as string;
-			expect(url).toContain("/sandboxes/sb-1/resume");
+			expect((await client.pause("sb-1")).status).toBe(SandboxStatus.Pausing);
 		});
 
-		it("resumeInfo parses pool resume hint", async () => {
+		it("resume sends POST to /resume and returns the accepted Sandbox body", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", phase: "Resuming" }, 202));
+
+			const client = new SandboxClient(makeConfig());
+			const info = await client.resume("sb-1");
+
+			expect(mockFetch.mock.calls[0][0] as string).toContain("/sandboxes/sb-1/resume");
+			expect(info.status).toBe(SandboxStatus.Resuming);
+		});
+
+		it("resume defaults to Resuming when the body omits the phase", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1" }, 202));
+
+			const client = new SandboxClient(makeConfig());
+			expect((await client.resume("sb-1")).status).toBe(SandboxStatus.Resuming);
+		});
+
+		it("resume carries lastError through", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(
-				mockResponse({ name: "sb-1", phase: "Running", resumedFromPool: true }),
+				mockResponse({ name: "sb-1", phase: "Failed", lastError: "pvc restore failed" }, 202),
 			);
 
 			const client = new SandboxClient(makeConfig());
-			const result = await client.resumeInfo("sb-1");
-
-			expect(result.status).toBe(SandboxStatus.Running);
-			expect(result.resumedFromPool).toBe(true);
+			expect((await client.resume("sb-1")).lastError).toBe("pvc restore failed");
 		});
 
-		it("resumeInfo preserves non-running status from response", async () => {
+		it("resumeInfo stays available as an alias for resume", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(
-				mockResponse({ name: "sb-1", phase: "Pending", resumedFromPool: false }),
-			);
+			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", phase: "Resuming" }, 202));
 
 			const client = new SandboxClient(makeConfig());
-			const result = await client.resumeInfo("sb-1");
+			const info = await client.resumeInfo("sb-1");
 
-			expect(result.status).toBe(SandboxStatus.Pending);
-			expect(result.resumedFromPool).toBe(false);
-		});
-
-		it("resumeInfo handles legacy empty response", async () => {
-			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({}));
-
-			const client = new SandboxClient(makeConfig());
-			const result = await client.resumeInfo("sb-1");
-
-			expect(result.name).toBe("sb-1");
-			expect(result.status).toBe(SandboxStatus.Running);
-			expect(result.resumedFromPool).toBe(false);
+			expect(info.name).toBe("sb-1");
+			expect(info.status).toBe(SandboxStatus.Resuming);
 		});
 
 		it("pause throws SandboxError on 409", async () => {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -422,50 +422,57 @@ describe("SandboxClient", () => {
 	});
 
 	describe("pause/resume", () => {
-		it("pause sends POST to /pause and resolves with undefined", async () => {
+		it("pause returns the accepted Sandbox body", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
 
 			const client = new SandboxClient(makeConfig());
-			const result = await client.pause("sb-1");
-
-			expect(mockFetch.mock.calls[0][0] as string).toContain("/sandboxes/sb-1/pause");
-			// Pre-0.8 userspace signature: Promise<void>, not the admission body.
-			expect(result).toBeUndefined();
-		});
-
-		it("pauseInfo returns the accepted Sandbox body", async () => {
-			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
-
-			const client = new SandboxClient(makeConfig());
-			const info = await client.pauseInfo("sb-1");
+			const info = await client.pause("sb-1");
 
 			expect(mockFetch.mock.calls[0][0] as string).toContain("/sandboxes/sb-1/pause");
 			expect(info.name).toBe("sb-1");
 			expect(info.status).toBe(SandboxStatus.Pausing);
 		});
 
-		it("pauseInfo defaults to Pausing when the body omits the phase", async () => {
+		it("pause defaults to Pausing when the body omits the phase", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1" }, 202));
 
 			const client = new SandboxClient(makeConfig());
-			expect((await client.pauseInfo("sb-1")).status).toBe(SandboxStatus.Pausing);
+			expect((await client.pause("sb-1")).status).toBe(SandboxStatus.Pausing);
 		});
 
-		it("resume sends POST to /resume and resolves with undefined", async () => {
+		it("resume returns the accepted Sandbox body", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", phase: "Resuming" }, 202));
 
 			const client = new SandboxClient(makeConfig());
-			const result = await client.resume("sb-1");
+			const info = await client.resume("sb-1");
 
 			expect(mockFetch.mock.calls[0][0] as string).toContain("/sandboxes/sb-1/resume");
-			expect(result).toBeUndefined();
+			expect(info.name).toBe("sb-1");
+			expect(info.status).toBe(SandboxStatus.Resuming);
 		});
 
-		it("resumeInfo returns the accepted Sandbox body", async () => {
+		it("resume defaults to Resuming when the body omits the phase", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1" }, 202));
+
+			const client = new SandboxClient(makeConfig());
+			expect((await client.resume("sb-1")).status).toBe(SandboxStatus.Resuming);
+		});
+
+		it("resume carries lastError through", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(
+				mockResponse({ name: "sb-1", phase: "Failed", lastError: "pvc restore failed" }, 202),
+			);
+
+			const client = new SandboxClient(makeConfig());
+			expect((await client.resume("sb-1")).lastError).toBe("pvc restore failed");
+		});
+
+		it("resumeInfo stays as a deprecated alias for resume", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", phase: "Resuming" }, 202));
 
@@ -473,26 +480,7 @@ describe("SandboxClient", () => {
 			const info = await client.resumeInfo("sb-1");
 
 			expect(mockFetch.mock.calls[0][0] as string).toContain("/sandboxes/sb-1/resume");
-			expect(info.name).toBe("sb-1");
 			expect(info.status).toBe(SandboxStatus.Resuming);
-		});
-
-		it("resumeInfo defaults to Resuming when the body omits the phase", async () => {
-			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1" }, 202));
-
-			const client = new SandboxClient(makeConfig());
-			expect((await client.resumeInfo("sb-1")).status).toBe(SandboxStatus.Resuming);
-		});
-
-		it("resumeInfo carries lastError through", async () => {
-			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(
-				mockResponse({ name: "sb-1", phase: "Failed", lastError: "pvc restore failed" }, 202),
-			);
-
-			const client = new SandboxClient(makeConfig());
-			expect((await client.resumeInfo("sb-1")).lastError).toBe("pvc restore failed");
 		});
 
 		it("pause throws SandboxError on 409", async () => {
@@ -503,12 +491,12 @@ describe("SandboxClient", () => {
 			await expect(client.pause("sb-1")).rejects.toThrow(SandboxError);
 		});
 
-		it("pauseInfo throws SandboxError on 409", async () => {
+		it("pause 409 maps to SandboxError with the not-running hint", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ detail: "Not running" }, 409));
 
 			const client = new SandboxClient(makeConfig());
-			await expect(client.pauseInfo("sb-1")).rejects.toThrow(SandboxError);
+			await expect(client.pause("sb-1")).rejects.toThrow(/not in Running state/);
 		});
 
 		it("resume throws SandboxError on 409", async () => {
@@ -519,12 +507,12 @@ describe("SandboxClient", () => {
 			await expect(client.resume("sb-1")).rejects.toThrow(SandboxError);
 		});
 
-		it("resumeInfo throws SandboxError on 409", async () => {
+		it("resume 409 maps to SandboxError with the not-paused hint", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValue(mockResponse({ detail: "Not paused" }, 409));
 
 			const client = new SandboxClient(makeConfig());
-			await expect(client.resumeInfo("sb-1")).rejects.toThrow(SandboxError);
+			await expect(client.resume("sb-1")).rejects.toThrow(/not in Paused state/);
 		});
 	});
 

--- a/tests/compat.test.ts
+++ b/tests/compat.test.ts
@@ -1,0 +1,135 @@
+import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	MIN_BACKEND_VERSION,
+	checkBackendCompatibility,
+	parseVersion,
+} from "../src/common/compat.js";
+import { Config } from "../src/common/config.js";
+import { HttpClient } from "../src/common/http.js";
+import { mockResponse, versionResponse } from "./helpers.js";
+
+const baseConfig = {
+	apiUrl: "https://example.com",
+	workspace: "test-ns",
+	userId: "user@test.com",
+};
+
+describe("parseVersion", () => {
+	it("parses a plain three-part version", () => {
+		expect(parseVersion("1.2.3")).toEqual([1, 2, 3]);
+	});
+
+	it("drops pre-release and build suffixes", () => {
+		expect(parseVersion("1.2.3-dev")).toEqual([1, 2, 3]);
+		expect(parseVersion("1.2.3-alpha.1")).toEqual([1, 2, 3]);
+		expect(parseVersion("1.2.3+build.123")).toEqual([1, 2, 3]);
+	});
+
+	it("normalizes short versions to three components", () => {
+		expect(parseVersion("1.0")).toEqual([1, 0, 0]);
+		expect(parseVersion("1")).toEqual([1, 0, 0]);
+	});
+
+	it("tolerates a v prefix in either case", () => {
+		expect(parseVersion("v0.1.0")).toEqual([0, 1, 0]);
+		expect(parseVersion("V1.2.3")).toEqual([1, 2, 3]);
+	});
+
+	it("keeps the leading digits of an rc/beta/alpha component", () => {
+		expect(parseVersion("1.2.3rc1")).toEqual([1, 2, 3]);
+		expect(parseVersion("1.2.3beta2")).toEqual([1, 2, 3]);
+		expect(parseVersion("1.2.0a1")).toEqual([1, 2, 0]);
+	});
+});
+
+describe("MIN_BACKEND_VERSION", () => {
+	it("pins the v0.8 async lifecycle backend", () => {
+		expect(MIN_BACKEND_VERSION).toBe("0.8.0");
+	});
+});
+
+describe("checkBackendCompatibility", () => {
+	let warn: MockInstance<(...args: unknown[]) => void>;
+
+	beforeEach(() => {
+		vi.stubGlobal("fetch", vi.fn());
+		warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it("queries /api/version on the configured API URL", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValue(versionResponse("0.8.0"));
+
+		await checkBackendCompatibility(new HttpClient(new Config(baseConfig)));
+
+		expect(new URL(String(mockFetch.mock.calls[0][0])).pathname).toBe("/api/version");
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("warns when the backend is older than the minimum", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValue(versionResponse("0.7.9"));
+
+		await checkBackendCompatibility(new HttpClient(new Config(baseConfig)));
+
+		expect(warn).toHaveBeenCalledTimes(1);
+		const message = String(warn.mock.calls[0][0]);
+		expect(message).toContain("0.7.9");
+		expect(message).toContain("Minimum required backend version: 0.8.0");
+	});
+
+	it("stays silent for a newer backend", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValue(versionResponse("0.9.1"));
+
+		await checkBackendCompatibility(new HttpClient(new Config(baseConfig)));
+
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("stays silent when the backend does not report a version", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValue(mockResponse({}));
+
+		await checkBackendCompatibility(new HttpClient(new Config(baseConfig)));
+
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("skips the check entirely under API key auth", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValue(versionResponse("0.1.0"));
+
+		await checkBackendCompatibility(
+			new HttpClient(new Config({ ...baseConfig, apiKey: "secret" })),
+		);
+
+		expect(mockFetch).not.toHaveBeenCalled();
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("swallows an unreachable backend", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockRejectedValue(new Error("connection refused"));
+
+		await expect(
+			checkBackendCompatibility(new HttpClient(new Config(baseConfig))),
+		).resolves.toBeUndefined();
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("swallows a backend without a version endpoint", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValue(mockResponse({ detail: "Not Found" }, 404));
+
+		await expect(
+			checkBackendCompatibility(new HttpClient(new Config(baseConfig))),
+		).resolves.toBeUndefined();
+		expect(warn).not.toHaveBeenCalled();
+	});
+});

--- a/tests/e2e/live-config.ts
+++ b/tests/e2e/live-config.ts
@@ -1,0 +1,80 @@
+/**
+ * Side-effect-free environment parsing for the live Sandbox E2E suite.
+ *
+ * Mirrors `pk-sandbox/tests/e2e/live_sandbox_config.py` so the TypeScript and
+ * Python acceptance suites read exactly the same environment contract. Importing
+ * this module never touches the network and never reads `process.env`: parsing
+ * happens when {@link loadLiveSandboxConfig} is called, against the map you pass
+ * in (defaulting to `process.env`).
+ */
+
+import type { ConfigOptions } from "../../src/index.js";
+
+/** Environment variables without which no live test can run. */
+export const REQUIRED_ENV = ["PROKUBE_API_URL", "PROKUBE_WORKSPACE", "PROKUBE_API_KEY"] as const;
+
+/** Same default image the Python live suite uses. */
+export const DEFAULT_SANDBOX_IMAGE =
+	"europe-west3-docker.pkg.dev/prokube-internal/prokube-customer/pk-sandbox-base:v14-05-2026";
+
+/** A read-only view of an environment, so tests can pass literals. */
+export type Environ = Readonly<Record<string, string | undefined>>;
+
+/** Configuration shared by the live Sandbox test modules. */
+export interface LiveSandboxConfig {
+	/** Required variables that were absent or empty, in declaration order. */
+	readonly missingRequiredEnv: readonly string[];
+	readonly apiUrl: string;
+	readonly workspace: string;
+	readonly apiKey: string;
+	readonly sandboxImage: string;
+	/** Pre-existing warm pool to reuse; `undefined` means "create an ephemeral one". */
+	readonly poolName: string | undefined;
+	readonly poolSize: number;
+	readonly poolReadyTimeout: number;
+	/** Options accepted by every SDK entry point (`Sandbox.create`, ...). */
+	readonly sdkOptions: Required<Pick<ConfigOptions, "apiUrl" | "workspace" | "apiKey">>;
+}
+
+/**
+ * Read a positive integer environment variable.
+ *
+ * @throws Error naming the variable when the value is not a positive integer.
+ */
+export function positiveIntEnv(name: string, defaultValue: string, environ: Environ): number {
+	const rawValue = environ[name] ?? defaultValue;
+	// Mirror Python's int(): whole decimal integers only. Number() alone would
+	// accept "0x10", " ", "1e3" and "" — none of which int() parses.
+	if (!/^[+-]?\d+$/.test(rawValue.trim())) {
+		throw new Error(`${name} must be a positive integer, got: ${rawValue}`);
+	}
+	const value = Number(rawValue);
+	if (value <= 0) {
+		throw new Error(`${name} must be greater than 0, got: ${rawValue}`);
+	}
+	return value;
+}
+
+/** Parse the shared live Sandbox settings without creating runtime resources. */
+export function loadLiveSandboxConfig(environ: Environ = process.env): LiveSandboxConfig {
+	const apiUrl = environ.PROKUBE_API_URL ?? "";
+	const workspace = environ.PROKUBE_WORKSPACE ?? "";
+	const apiKey = environ.PROKUBE_API_KEY ?? "";
+
+	return {
+		missingRequiredEnv: REQUIRED_ENV.filter((name) => !environ[name]),
+		apiUrl,
+		workspace,
+		apiKey,
+		sandboxImage: environ.SANDBOX_IMAGE ?? DEFAULT_SANDBOX_IMAGE,
+		poolName: environ.SANDBOX_POOL,
+		poolSize: positiveIntEnv("SANDBOX_POOL_SIZE", "5", environ),
+		poolReadyTimeout: positiveIntEnv("SANDBOX_POOL_READY_TIMEOUT", "120", environ),
+		sdkOptions: { apiUrl, workspace, apiKey },
+	};
+}
+
+/** Human-readable reason to print when the live suite is skipped. */
+export function skipReason(config: LiveSandboxConfig): string {
+	return `live Sandbox E2E tests require ${config.missingRequiredEnv.join(", ")}`;
+}

--- a/tests/e2e/live-sandbox.test.ts
+++ b/tests/e2e/live-sandbox.test.ts
@@ -22,6 +22,7 @@ import {
 	SandboxStatus,
 } from "../../src/index.js";
 import { loadLiveSandboxConfig, skipReason } from "./live-config.js";
+import { printTimingReport, timed } from "./timing.js";
 
 const config = loadLiveSandboxConfig();
 const SKIP = config.missingRequiredEnv.length > 0;
@@ -34,6 +35,10 @@ const { sdkOptions, sandboxImage } = config;
 
 /** Unique per run so concurrent runs against one cluster cannot collide. */
 const RUN_ID = `ts-e2e-${Date.now().toString(36)}-${Math.floor(Math.random() * 4096).toString(36)}`;
+
+afterAll(() => {
+	printTimingReport(`Live E2E timings — single round (run ${RUN_ID})`);
+});
 
 /** Seconds to wait for a cold sandbox to become Running. */
 const READY_TIMEOUT = 300;
@@ -97,8 +102,10 @@ describe.skipIf(SKIP)("live sandbox: direct create lifecycle", () => {
 	}
 
 	beforeAll(async () => {
-		sandbox = await Sandbox.create(sandboxImage, { ...sdkOptions, name });
-		await sandbox.waitUntilReady(READY_TIMEOUT);
+		sandbox = await timed("Sandbox.create (admission)", () =>
+			Sandbox.create(sandboxImage, { ...sdkOptions, name }),
+		);
+		await timed("waitUntilReady after create", () => activeSandbox().waitUntilReady(READY_TIMEOUT));
 		expect(sandbox.name).toBe(name);
 		expect(await sandbox.getPhase()).toBe(SandboxStatus.Running);
 	});
@@ -109,12 +116,16 @@ describe.skipIf(SKIP)("live sandbox: direct create lifecycle", () => {
 	});
 
 	it("keeps Jupyter session state across runCode calls", async () => {
-		const first = await activeSandbox().runCode("e2e_marker = 41 + 1");
+		const first = await timed("first runCode", () =>
+			activeSandbox().runCode("e2e_marker = 41 + 1"),
+		);
 		expect(first.success, `stderr: ${first.stderr}`).toBe(true);
 		const sessionId = activeSandbox().sessionId;
 		expect(sessionId).toBeTruthy();
 
-		const second = await activeSandbox().runCode("print(e2e_marker)");
+		const second = await timed("runCode (cached session)", () =>
+			activeSandbox().runCode("print(e2e_marker)"),
+		);
 		expect(second.success, `stderr: ${second.stderr}`).toBe(true);
 		expect(second.stdout).toContain("42");
 		expect(activeSandbox().sessionId).toBe(sessionId);
@@ -125,7 +136,9 @@ describe.skipIf(SKIP)("live sandbox: direct create lifecycle", () => {
 		activeSandbox().resetSession();
 		expect(activeSandbox().sessionId).toBeUndefined();
 
-		const result = await activeSandbox().runCode("print(e2e_marker)");
+		const result = await timed("runCode after resetSession", () =>
+			activeSandbox().runCode("print(e2e_marker)"),
+		);
 		expect(result.success).toBe(false);
 		expect(`${result.errorName ?? ""}${result.stderr}`).toContain("NameError");
 		// A fresh kernel means a different session id.
@@ -134,7 +147,9 @@ describe.skipIf(SKIP)("live sandbox: direct create lifecycle", () => {
 	});
 
 	it("runs shell commands and reports exit codes", async () => {
-		const ok = await activeSandbox().commands.run("echo e2e-shell-ok");
+		const ok = await timed("commands.run (echo)", () =>
+			activeSandbox().commands.run("echo e2e-shell-ok"),
+		);
 		expect(ok.exitCode).toBe(0);
 		expect(ok.stdout).toContain("e2e-shell-ok");
 
@@ -143,8 +158,10 @@ describe.skipIf(SKIP)("live sandbox: direct create lifecycle", () => {
 	});
 
 	it("round-trips text and binary files", async () => {
-		await activeSandbox().files.write(textPath, textContent);
-		expect(decoder.decode(await activeSandbox().files.read(textPath))).toBe(textContent);
+		await timed("files.write (text)", () => activeSandbox().files.write(textPath, textContent));
+		expect(
+			decoder.decode(await timed("files.read (text)", () => activeSandbox().files.read(textPath))),
+		).toBe(textContent);
 
 		await activeSandbox().files.write(binaryPath, binaryContent);
 		const readBack = await activeSandbox().files.read(binaryPath);
@@ -152,16 +169,18 @@ describe.skipIf(SKIP)("live sandbox: direct create lifecycle", () => {
 	});
 
 	it("writes a batch and lists the directory", async () => {
-		const batch = await activeSandbox().files.writeBatch([
-			{ path: "/workspace/e2e-batch-1.txt", content: "batch-one" },
-			{ path: "/workspace/e2e-batch-2.txt", content: new Uint8Array([98, 116, 119, 111]) },
-		]);
+		const batch = await timed("files.writeBatch (2 items)", () =>
+			activeSandbox().files.writeBatch([
+				{ path: "/workspace/e2e-batch-1.txt", content: "batch-one" },
+				{ path: "/workspace/e2e-batch-2.txt", content: new Uint8Array([98, 116, 119, 111]) },
+			]),
+		);
 		expect(batch.total).toBe(2);
 		expect(batch.successCount, JSON.stringify(batch.results)).toBe(2);
 		expect(batch.failureCount).toBe(0);
 		expect(batch.success).toBe(true);
 
-		const entries = await activeSandbox().files.list("/workspace");
+		const entries = await timed("files.list", () => activeSandbox().files.list("/workspace"));
 		const names = entries.map((entry) => entry.name);
 		expect(names).toContain("e2e-batch-1.txt");
 		expect(names).toContain("e2e-batch-2.txt");
@@ -169,14 +188,16 @@ describe.skipIf(SKIP)("live sandbox: direct create lifecycle", () => {
 	});
 
 	it("finds the sandbox via get, list and listPage", async () => {
-		const fetched = await Sandbox.get(name, sdkOptions);
+		const fetched = await timed("Sandbox.get", () => Sandbox.get(name, sdkOptions));
 		expect(fetched.name).toBe(name);
 		expect(fetched.status).toBe(SandboxStatus.Running);
 
-		const all = await Sandbox.list(sdkOptions);
+		const all = await timed("Sandbox.list", () => Sandbox.list(sdkOptions));
 		expect(all.map((entry) => entry.name)).toContain(name);
 
-		const page = await Sandbox.listPage({ ...sdkOptions, limit: 1 });
+		const page = await timed("Sandbox.listPage (limit 1)", () =>
+			Sandbox.listPage({ ...sdkOptions, limit: 1 }),
+		);
 		expect(page.loaded).toBeLessThanOrEqual(1);
 		expect(page.sandboxes.length).toBeLessThanOrEqual(page.loaded);
 		expect(typeof page.hasMore).toBe("boolean");
@@ -203,14 +224,16 @@ describe.skipIf(SKIP)("live sandbox: direct create lifecycle", () => {
 		const seeded = await activeSandbox().runCode("pause_marker = 'survives-nothing'");
 		expect(seeded.success, `stderr: ${seeded.stderr}`).toBe(true);
 
-		await activeSandbox().pause({ wait: true, timeout: LIFECYCLE_TIMEOUT });
+		await timed("pause (wait=true)", () =>
+			activeSandbox().pause({ wait: true, timeout: LIFECYCLE_TIMEOUT }),
+		);
 		expect(activeSandbox().status).toBe(SandboxStatus.Paused);
 		expect(await activeSandbox().getPhase()).toBe(SandboxStatus.Paused);
 	});
 
 	it("resumes with /workspace intact and the Jupyter session gone", async () => {
-		await activeSandbox().resume();
-		await activeSandbox().waitUntilReady(READY_TIMEOUT);
+		await timed("resume (admission)", () => activeSandbox().resume());
+		await timed("waitUntilReady after resume", () => activeSandbox().waitUntilReady(READY_TIMEOUT));
 		expect(await activeSandbox().getPhase()).toBe(SandboxStatus.Running);
 
 		// Persisted volume survives.
@@ -223,7 +246,9 @@ describe.skipIf(SKIP)("live sandbox: direct create lifecycle", () => {
 	});
 
 	it("kills the sandbox and then reports it as not found", async () => {
-		await activeSandbox().kill({ wait: true, timeout: LIFECYCLE_TIMEOUT });
+		await timed("kill (wait=true)", () =>
+			activeSandbox().kill({ wait: true, timeout: LIFECYCLE_TIMEOUT }),
+		);
 		killed = true;
 
 		await expect(Sandbox.get(name, sdkOptions)).rejects.toBeInstanceOf(SandboxNotFoundError);
@@ -245,29 +270,33 @@ describe.skipIf(SKIP)("live sandbox: warm pool claim", () => {
 		if (config.poolName) {
 			poolName = config.poolName;
 		} else {
-			ephemeralPool = await SandboxPool.create({
-				...sdkOptions,
-				name: ephemeralPoolName,
-				image: sandboxImage,
-				poolSize: ephemeralPoolSize,
-			});
+			ephemeralPool = await timed("SandboxPool.create (admission)", () =>
+				SandboxPool.create({
+					...sdkOptions,
+					name: ephemeralPoolName,
+					image: sandboxImage,
+					poolSize: ephemeralPoolSize,
+				}),
+			);
 			poolName = ephemeralPool.name;
 		}
 
 		const pool = ephemeralPool ?? (await SandboxPool.get(poolName, sdkOptions));
-		const deadline = Date.now() + config.poolReadyTimeout * 1000;
-		while (pool.readyReplicas < 1) {
-			if (Date.now() >= deadline) {
-				throw new Error(
-					`pool '${poolName}' had no ready replica within ${config.poolReadyTimeout}s ` +
-						`(replicas=${pool.replicas}, readyReplicas=${pool.readyReplicas})`,
-				);
+		await timed("pool ready (poll readyReplicas>0)", async () => {
+			const deadline = Date.now() + config.poolReadyTimeout * 1000;
+			while (pool.readyReplicas < 1) {
+				if (Date.now() >= deadline) {
+					throw new Error(
+						`pool '${poolName}' had no ready replica within ${config.poolReadyTimeout}s ` +
+							`(replicas=${pool.replicas}, readyReplicas=${pool.readyReplicas})`,
+					);
+				}
+				// Real delay on purpose: pool readiness is a cluster-side convergence
+				// with no client-side signal to await, so there is no clock to fake.
+				await delay(2000);
+				await pool.refresh();
 			}
-			// Real delay on purpose: pool readiness is a cluster-side convergence
-			// with no client-side signal to await, so there is no clock to fake.
-			await delay(2000);
-			await pool.refresh();
-		}
+		});
 		expect(pool.readyReplicas).toBeGreaterThan(0);
 	});
 
@@ -277,15 +306,20 @@ describe.skipIf(SKIP)("live sandbox: warm pool claim", () => {
 	});
 
 	it("claims a sandbox from the pool and runs code in it", async () => {
-		claimed = await Sandbox.fromPool(poolName, sdkOptions);
-		await claimed.waitUntilReady(READY_TIMEOUT);
+		claimed = await timed("Sandbox.fromPool (claim)", () => Sandbox.fromPool(poolName, sdkOptions));
+		const claimedSandbox = claimed;
+		await timed("waitUntilReady after claim", () => claimedSandbox.waitUntilReady(READY_TIMEOUT));
 		expect(await claimed.getPhase()).toBe(SandboxStatus.Running);
 
-		const result = await claimed.runCode("print(6 * 7)");
+		const result = await timed("runCode in claimed sandbox", () =>
+			claimedSandbox.runCode("print(6 * 7)"),
+		);
 		expect(result.success, `stderr: ${result.stderr}`).toBe(true);
 		expect(result.stdout).toContain("42");
 
-		await claimed.kill({ wait: true, timeout: LIFECYCLE_TIMEOUT });
+		await timed("kill claimed (wait=true)", () =>
+			claimedSandbox.kill({ wait: true, timeout: LIFECYCLE_TIMEOUT }),
+		);
 		claimed = undefined;
 	});
 });

--- a/tests/e2e/live-sandbox.test.ts
+++ b/tests/e2e/live-sandbox.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Live acceptance suite for the TypeScript SDK.
+ *
+ * This file talks to a real pk-sandbox deployment and creates real, billable
+ * resources. It is excluded from `npm test`; run it explicitly with
+ * `npm run test:e2e` and real credentials. Without the required environment
+ * every describe below skips cleanly (exit 0), so the command is safe to run
+ * anywhere.
+ *
+ * Mirrors the scenarios of `pk-sandbox/tests/e2e/` against the public SDK
+ * surface only — nothing here reaches past `src/index.js`.
+ */
+
+import { setTimeout as delay } from "node:timers/promises";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+	NotFoundError,
+	Sandbox,
+	SandboxError,
+	SandboxNotFoundError,
+	SandboxPool,
+	SandboxStatus,
+} from "../../src/index.js";
+import { loadLiveSandboxConfig, skipReason } from "./live-config.js";
+
+const config = loadLiveSandboxConfig();
+const SKIP = config.missingRequiredEnv.length > 0;
+
+if (SKIP) {
+	console.warn(`[e2e] skipped: ${skipReason(config)}`);
+}
+
+const { sdkOptions, sandboxImage } = config;
+
+/** Unique per run so concurrent runs against one cluster cannot collide. */
+const RUN_ID = `ts-e2e-${Date.now().toString(36)}-${Math.floor(Math.random() * 4096).toString(36)}`;
+
+/** Seconds to wait for a cold sandbox to become Running. */
+const READY_TIMEOUT = 300;
+/** Seconds to wait for pause/delete to settle. */
+const LIFECYCLE_TIMEOUT = 300;
+
+/**
+ * Ephemeral pools are created only to prove the claim path works, so they stay
+ * deliberately small regardless of the Python-parity `SANDBOX_POOL_SIZE`
+ * default of 5. Setting `SANDBOX_POOL_SIZE=1` shrinks it further.
+ */
+const ephemeralPoolSize = Math.min(config.poolSize, 2);
+
+const decoder = new TextDecoder();
+
+/** Kill a sandbox during cleanup: never throws, tolerates an already-gone row. */
+async function safeKill(sandbox: Sandbox | undefined): Promise<void> {
+	if (!sandbox) return;
+	try {
+		await sandbox.kill({ wait: true, timeout: LIFECYCLE_TIMEOUT });
+	} catch (error) {
+		if (error instanceof SandboxNotFoundError || error instanceof NotFoundError) return;
+		console.warn(`[e2e] cleanup: failed to kill '${sandbox.name}': ${String(error)}`);
+	}
+}
+
+/** Delete a pool during cleanup: never throws, tolerates an already-gone pool. */
+async function safeDeletePool(pool: SandboxPool | undefined): Promise<void> {
+	if (!pool) return;
+	try {
+		await pool.delete();
+	} catch (error) {
+		if (error instanceof SandboxNotFoundError || error instanceof NotFoundError) return;
+		console.warn(`[e2e] cleanup: failed to delete pool '${pool.name}': ${String(error)}`);
+	}
+}
+
+// ===========================================================================
+// 1. Direct create path: full lifecycle against a cold-started sandbox
+// ===========================================================================
+
+describe.skipIf(SKIP)("live sandbox: direct create lifecycle", () => {
+	const name = `${RUN_ID}-direct`;
+	const textPath = "/workspace/e2e-text.txt";
+	const binaryPath = "/workspace/e2e-binary.bin";
+	const textContent = `hello from ${name}`;
+	const binaryContent = new Uint8Array(256).map((_unused, index) => index);
+
+	let sandbox: Sandbox | undefined;
+	/** Set once the sandbox has been deleted, so afterAll does not re-kill it. */
+	let killed = false;
+
+	/**
+	 * The sandbox every step below operates on. Narrows the shared `undefined`
+	 * slot (needed by cleanup) and fails loudly rather than skipping silently
+	 * when creation in `beforeAll` did not happen.
+	 */
+	function activeSandbox(): Sandbox {
+		if (!sandbox) throw new Error(`live sandbox '${name}' was never created`);
+		return sandbox;
+	}
+
+	beforeAll(async () => {
+		sandbox = await Sandbox.create(sandboxImage, { ...sdkOptions, name });
+		await sandbox.waitUntilReady(READY_TIMEOUT);
+		expect(sandbox.name).toBe(name);
+		expect(await sandbox.getPhase()).toBe(SandboxStatus.Running);
+	});
+
+	afterAll(async () => {
+		if (killed) return;
+		await safeKill(sandbox);
+	});
+
+	it("keeps Jupyter session state across runCode calls", async () => {
+		const first = await activeSandbox().runCode("e2e_marker = 41 + 1");
+		expect(first.success, `stderr: ${first.stderr}`).toBe(true);
+		const sessionId = activeSandbox().sessionId;
+		expect(sessionId).toBeTruthy();
+
+		const second = await activeSandbox().runCode("print(e2e_marker)");
+		expect(second.success, `stderr: ${second.stderr}`).toBe(true);
+		expect(second.stdout).toContain("42");
+		expect(activeSandbox().sessionId).toBe(sessionId);
+	});
+
+	it("drops that state after resetSession()", async () => {
+		const previousSessionId = activeSandbox().sessionId;
+		activeSandbox().resetSession();
+		expect(activeSandbox().sessionId).toBeUndefined();
+
+		const result = await activeSandbox().runCode("print(e2e_marker)");
+		expect(result.success).toBe(false);
+		expect(`${result.errorName ?? ""}${result.stderr}`).toContain("NameError");
+		// A fresh kernel means a different session id.
+		expect(activeSandbox().sessionId).toBeTruthy();
+		expect(activeSandbox().sessionId).not.toBe(previousSessionId);
+	});
+
+	it("runs shell commands and reports exit codes", async () => {
+		const ok = await activeSandbox().commands.run("echo e2e-shell-ok");
+		expect(ok.exitCode).toBe(0);
+		expect(ok.stdout).toContain("e2e-shell-ok");
+
+		const failed = await activeSandbox().commands.run("exit 3");
+		expect(failed.exitCode).toBe(3);
+	});
+
+	it("round-trips text and binary files", async () => {
+		await activeSandbox().files.write(textPath, textContent);
+		expect(decoder.decode(await activeSandbox().files.read(textPath))).toBe(textContent);
+
+		await activeSandbox().files.write(binaryPath, binaryContent);
+		const readBack = await activeSandbox().files.read(binaryPath);
+		expect(Array.from(readBack)).toEqual(Array.from(binaryContent));
+	});
+
+	it("writes a batch and lists the directory", async () => {
+		const batch = await activeSandbox().files.writeBatch([
+			{ path: "/workspace/e2e-batch-1.txt", content: "batch-one" },
+			{ path: "/workspace/e2e-batch-2.txt", content: new Uint8Array([98, 116, 119, 111]) },
+		]);
+		expect(batch.total).toBe(2);
+		expect(batch.successCount, JSON.stringify(batch.results)).toBe(2);
+		expect(batch.failureCount).toBe(0);
+		expect(batch.success).toBe(true);
+
+		const entries = await activeSandbox().files.list("/workspace");
+		const names = entries.map((entry) => entry.name);
+		expect(names).toContain("e2e-batch-1.txt");
+		expect(names).toContain("e2e-batch-2.txt");
+		expect(names).toContain("e2e-text.txt");
+	});
+
+	it("finds the sandbox via get, list and listPage", async () => {
+		const fetched = await Sandbox.get(name, sdkOptions);
+		expect(fetched.name).toBe(name);
+		expect(fetched.status).toBe(SandboxStatus.Running);
+
+		const all = await Sandbox.list(sdkOptions);
+		expect(all.map((entry) => entry.name)).toContain(name);
+
+		const page = await Sandbox.listPage({ ...sdkOptions, limit: 1 });
+		expect(page.loaded).toBeLessThanOrEqual(1);
+		expect(page.sandboxes.length).toBeLessThanOrEqual(page.loaded);
+		expect(typeof page.hasMore).toBe("boolean");
+
+		if (page.hasMore) {
+			expect(page.continueToken).toBeTruthy();
+			const next = await Sandbox.listPage({
+				...sdkOptions,
+				limit: 1,
+				continueToken: page.continueToken,
+			});
+			expect(next.loaded).toBeLessThanOrEqual(1);
+			const firstNames = page.sandboxes.map((entry) => entry.name);
+			for (const entry of next.sandboxes) {
+				expect(firstNames).not.toContain(entry.name);
+			}
+		} else {
+			expect(page.continueToken).toBeUndefined();
+		}
+	});
+
+	it("pauses the sandbox", async () => {
+		// Re-establish kernel state so the resume step can prove it is lost.
+		const seeded = await activeSandbox().runCode("pause_marker = 'survives-nothing'");
+		expect(seeded.success, `stderr: ${seeded.stderr}`).toBe(true);
+
+		await activeSandbox().pause({ wait: true, timeout: LIFECYCLE_TIMEOUT });
+		expect(activeSandbox().status).toBe(SandboxStatus.Paused);
+		expect(await activeSandbox().getPhase()).toBe(SandboxStatus.Paused);
+	});
+
+	it("resumes with /workspace intact and the Jupyter session gone", async () => {
+		await activeSandbox().resume();
+		await activeSandbox().waitUntilReady(READY_TIMEOUT);
+		expect(await activeSandbox().getPhase()).toBe(SandboxStatus.Running);
+
+		// Persisted volume survives.
+		expect(decoder.decode(await activeSandbox().files.read(textPath))).toBe(textContent);
+
+		// Kernel state does not: the pod was torn down and rebuilt.
+		const result = await activeSandbox().runCode("print(pause_marker)");
+		expect(result.success).toBe(false);
+		expect(`${result.errorName ?? ""}${result.stderr}`).toContain("NameError");
+	});
+
+	it("kills the sandbox and then reports it as not found", async () => {
+		await activeSandbox().kill({ wait: true, timeout: LIFECYCLE_TIMEOUT });
+		killed = true;
+
+		await expect(Sandbox.get(name, sdkOptions)).rejects.toBeInstanceOf(SandboxNotFoundError);
+	});
+});
+
+// ===========================================================================
+// 2. Pool path: claim a warm sandbox
+// ===========================================================================
+
+describe.skipIf(SKIP)("live sandbox: warm pool claim", () => {
+	const ephemeralPoolName = `${RUN_ID}-pool`;
+	/** Only set when this suite created the pool, so cleanup deletes only ours. */
+	let ephemeralPool: SandboxPool | undefined;
+	let poolName: string;
+	let claimed: Sandbox | undefined;
+
+	beforeAll(async () => {
+		if (config.poolName) {
+			poolName = config.poolName;
+		} else {
+			ephemeralPool = await SandboxPool.create({
+				...sdkOptions,
+				name: ephemeralPoolName,
+				image: sandboxImage,
+				poolSize: ephemeralPoolSize,
+			});
+			poolName = ephemeralPool.name;
+		}
+
+		const pool = ephemeralPool ?? (await SandboxPool.get(poolName, sdkOptions));
+		const deadline = Date.now() + config.poolReadyTimeout * 1000;
+		while (pool.readyReplicas < 1) {
+			if (Date.now() >= deadline) {
+				throw new Error(
+					`pool '${poolName}' had no ready replica within ${config.poolReadyTimeout}s ` +
+						`(replicas=${pool.replicas}, readyReplicas=${pool.readyReplicas})`,
+				);
+			}
+			// Real delay on purpose: pool readiness is a cluster-side convergence
+			// with no client-side signal to await, so there is no clock to fake.
+			await delay(2000);
+			await pool.refresh();
+		}
+		expect(pool.readyReplicas).toBeGreaterThan(0);
+	});
+
+	afterAll(async () => {
+		await safeKill(claimed);
+		await safeDeletePool(ephemeralPool);
+	});
+
+	it("claims a sandbox from the pool and runs code in it", async () => {
+		claimed = await Sandbox.fromPool(poolName, sdkOptions);
+		await claimed.waitUntilReady(READY_TIMEOUT);
+		expect(await claimed.getPhase()).toBe(SandboxStatus.Running);
+
+		const result = await claimed.runCode("print(6 * 7)");
+		expect(result.success, `stderr: ${result.stderr}`).toBe(true);
+		expect(result.stdout).toContain("42");
+
+		await claimed.kill({ wait: true, timeout: LIFECYCLE_TIMEOUT });
+		claimed = undefined;
+	});
+});
+
+// ===========================================================================
+// 3. Error surface
+// ===========================================================================
+
+describe.skipIf(SKIP)("live sandbox: error surface", () => {
+	it("rejects Sandbox.get for a name that does not exist", async () => {
+		await expect(Sandbox.get(`${RUN_ID}-absent`, sdkOptions)).rejects.toBeInstanceOf(
+			SandboxNotFoundError,
+		);
+	});
+
+	it("rejects pause on an already-killed sandbox", async () => {
+		const name = `${RUN_ID}-doomed`;
+		const sandbox = await Sandbox.create(sandboxImage, { ...sdkOptions, name });
+		try {
+			await sandbox.kill({ wait: true, timeout: LIFECYCLE_TIMEOUT });
+			await expect(sandbox.pause({ wait: false })).rejects.toBeInstanceOf(SandboxError);
+		} finally {
+			await safeKill(sandbox);
+		}
+	});
+});

--- a/tests/e2e/timing.ts
+++ b/tests/e2e/timing.ts
@@ -1,0 +1,50 @@
+/**
+ * Wall-clock timing collection for the live E2E suite.
+ *
+ * Mirrors the per-operation table printed by pk-sandbox's
+ * `tests/e2e/bench_sandbox.py` (`_print_single`), for a single round: the
+ * suite exercises each lifecycle operation once, so there is no median or
+ * range column.
+ */
+
+interface Timing {
+	label: string;
+	seconds: number;
+	failed: boolean;
+}
+
+const timings: Timing[] = [];
+
+/** Run `operation`, recording its wall-clock duration under `label`. */
+export async function timed<T>(label: string, operation: () => Promise<T>): Promise<T> {
+	const start = performance.now();
+	try {
+		const result = await operation();
+		timings.push({ label, seconds: (performance.now() - start) / 1000, failed: false });
+		return result;
+	} catch (error) {
+		timings.push({ label, seconds: (performance.now() - start) / 1000, failed: true });
+		throw error;
+	}
+}
+
+/** Print the collected timings as a table; no-op when nothing was recorded. */
+export function printTimingReport(title: string): void {
+	if (timings.length === 0) return;
+
+	const labelWidth = Math.max(...timings.map((entry) => entry.label.length), "Operation".length);
+	const rule = "=".repeat(labelWidth + 16);
+	const lines = [
+		rule,
+		`  ${title}`,
+		rule,
+		`  ${"Operation".padEnd(labelWidth)} ${"Duration".padStart(10)}`,
+		`  ${"-".repeat(labelWidth)} ${"-".repeat(10)}`,
+	];
+	for (const { label, seconds, failed } of timings) {
+		const duration = `${seconds.toFixed(3)}s${failed ? " !" : ""}`;
+		lines.push(`  ${label.padEnd(labelWidth)} ${duration.padStart(10)}`);
+	}
+	lines.push(rule);
+	console.info(`\n${lines.join("\n")}\n`);
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,95 @@
+import { vi } from "vitest";
+
+/** A single recorded `fetch` invocation: `[input, init]`. */
+export type FetchCall = [input: unknown, init?: RequestInit];
+
+export function mockResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+/**
+ * Body served by `GET /api/version`.
+ *
+ * Every `Sandbox.*` / `SandboxPool.*` static factory awaits
+ * `SandboxClient.ensureCompatibility()` first, so this is the *first* fetch
+ * of any factory-driven flow. Tests that chain `mockResolvedValueOnce` must
+ * enqueue it explicitly; tests using a persistent `mockResolvedValue` get
+ * their generic body served here too (no `version` key means the check is a
+ * silent no-op).
+ */
+export function versionResponse(version = "0.8.0"): Response {
+	return mockResponse({ version });
+}
+
+/**
+ * Recorded fetch calls with the compatibility probe filtered out, so
+ * positional assertions stay stable regardless of whether a given flow
+ * performed a version check.
+ */
+export function apiCalls(mockFetch: { mock: { calls: unknown[][] } }): FetchCall[] {
+	return (mockFetch.mock.calls as FetchCall[]).filter(
+		(call) => !new URL(String(call[0])).pathname.endsWith("/api/version"),
+	);
+}
+
+/** Recorded calls whose path ends in `suffix` (e.g. `sb-1`, `sb-1/pause`). */
+export function callsTo(
+	mockFetch: { mock: { calls: unknown[][] } },
+	suffix: string,
+	method?: string,
+): FetchCall[] {
+	return apiCalls(mockFetch).filter(
+		(call) =>
+			new URL(String(call[0])).pathname.endsWith(suffix) &&
+			(method === undefined || (call[1]?.method ?? "GET") === method),
+	);
+}
+
+/**
+ * Answer a kernel warmup probe by echoing its marker back.
+ *
+ * `waitUntilReady` proves the Jupyter pipeline is live by running
+ * `print("__pk_warmup_<uuid>__")` until that exact marker shows up in stdout.
+ * Throwing on an unrecognized body is deliberate: echoing an empty marker
+ * would make the probe succeed vacuously and hide format regressions.
+ */
+export function warmupProbeResponse(requestBody: string): Response {
+	const code = JSON.parse(requestBody).code as string;
+	const match = code.match(/print\("(__pk_warmup_[a-f0-9]+__)"\)/);
+	if (!match) {
+		throw new Error(`Unexpected warmup probe request body: ${requestBody}`);
+	}
+	return mockResponse({
+		stdout: `${match[1]}\n`,
+		stderr: "",
+		success: true,
+		durationMs: 5,
+		session_id: "sess-warm",
+	});
+}
+
+/**
+ * Reject the way `AbortSignal.timeout` does, so `HttpClient` can map it onto
+ * `RequestTimeoutError` (the TS stand-in for `httpx.TimeoutException`).
+ */
+export function abortTimeoutError(): DOMException {
+	return new DOMException("The operation was aborted due to timeout", "TimeoutError");
+}
+
+/**
+ * Capture the millisecond budgets handed to `AbortSignal.timeout`, which is
+ * how `HttpClient` bounds a single request. Returns the (live) array the spy
+ * appends to.
+ */
+export function captureRequestTimeouts(): number[] {
+	const captured: number[] = [];
+	const original = AbortSignal.timeout.bind(AbortSignal);
+	vi.spyOn(AbortSignal, "timeout").mockImplementation((ms: number) => {
+		captured.push(ms);
+		return original(ms);
+	});
+	return captured;
+}

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -5,10 +5,14 @@ import {
 	NotFoundError,
 	PoolExhaustedError,
 	ProKubeError,
+	RequestTimeoutError,
 } from "../src/common/errors.js";
 import { HttpClient } from "../src/common/http.js";
+import { abortTimeoutError, captureRequestTimeouts } from "./helpers.js";
 
-function makeConfig(overrides: Partial<{ apiKey: string; userId: string }> = {}): Config {
+function makeConfig(
+	overrides: Partial<{ apiKey: string; userId: string; timeout: number }> = {},
+): Config {
 	return new Config({
 		apiUrl: "https://example.com/pkui",
 		workspace: "test-ns",
@@ -218,5 +222,72 @@ describe("HttpClient", () => {
 
 		const url = mockFetch.mock.calls[0][0] as string;
 		expect(url).toBe("https://example.com/pkui/_platform/sandbox/ns/sandboxes");
+	});
+
+	describe("per-request timeout", () => {
+		it("arms an abort signal with the configured timeout by default", async () => {
+			const budgets = captureRequestTimeouts();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+			const client = new HttpClient(makeConfig({ timeout: 30 }));
+			await client.get("/api/test");
+
+			expect(budgets).toEqual([30_000]);
+			expect((mockFetch.mock.calls[0][1] as RequestInit).signal).toBeInstanceOf(AbortSignal);
+		});
+
+		it("lets a caller bound one request to a shorter budget", async () => {
+			const budgets = captureRequestTimeouts();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockImplementation(async () => new Response(JSON.stringify({}), { status: 200 }));
+
+			const client = new HttpClient(makeConfig({ timeout: 300 }));
+			await client.get("/api/test", undefined, 2.5);
+			await client.post("/api/test", { a: 1 }, 4);
+			await client.delete("/api/test", 1);
+
+			expect(budgets).toEqual([2_500, 4_000, 1_000]);
+		});
+
+		it("floors a sub-millisecond budget to 1ms instead of dropping the timeout", async () => {
+			const budgets = captureRequestTimeouts();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+			await new HttpClient(makeConfig()).get("/api/test", undefined, 0);
+
+			expect(budgets).toEqual([1]);
+		});
+
+		it("normalizes a timeout abort into RequestTimeoutError", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockRejectedValue(abortTimeoutError());
+
+			const client = new HttpClient(makeConfig());
+			await expect(client.get("/api/test", undefined, 1)).rejects.toBeInstanceOf(
+				RequestTimeoutError,
+			);
+		});
+
+		it("normalizes a timeout abort wrapped in a cause chain", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockRejectedValue(new TypeError("fetch failed", { cause: abortTimeoutError() }));
+
+			const client = new HttpClient(makeConfig());
+			await expect(client.get("/api/test", undefined, 1)).rejects.toBeInstanceOf(
+				RequestTimeoutError,
+			);
+		});
+
+		it("leaves an unrelated transport failure untouched", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockRejectedValue(new TypeError("connection refused"));
+
+			const client = new HttpClient(makeConfig());
+			const failure = client.get("/api/test");
+			await expect(failure).rejects.toBeInstanceOf(TypeError);
+			await expect(failure).rejects.not.toBeInstanceOf(RequestTimeoutError);
+		});
 	});
 });

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -1,0 +1,402 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SandboxError, SandboxTimeoutError } from "../src/common/errors.js";
+import { SandboxStatus } from "../src/sandbox/models.js";
+import { Sandbox } from "../src/sandbox/sandbox.js";
+import {
+	abortTimeoutError,
+	callsTo,
+	captureRequestTimeouts,
+	mockResponse,
+	versionResponse,
+	warmupProbeResponse,
+} from "./helpers.js";
+
+const defaultConfig = {
+	apiUrl: "https://example.com/pkui",
+	workspace: "test-ns",
+	userId: "user@test.com",
+};
+
+/**
+ * v0.8 admits every mutation with 202 and returns the full Sandbox body, so
+ * the claim response looks exactly like a GET.
+ */
+function claimResponse(phase = "Running"): Response {
+	return mockResponse({ name: "sb-1", namespace: "test-ns", phase, poolName: "pool" }, 202);
+}
+
+function getResponse(phase: string, extra: Record<string, unknown> = {}): Response {
+	return mockResponse({ name: "sb-1", phase, ...extra });
+}
+
+/**
+ * The sandbox lifecycle is a poll loop with a 2s interval, so every test that
+ * exercises more than one poll drives fake timers. Advancing exactly
+ * `(polls - 1) * 2000` keeps the queued response list and the loop in step.
+ */
+const POLL_INTERVAL_MS = 2000;
+
+describe("v0.8 lifecycle", () => {
+	const originalEnv = process.env;
+
+	beforeEach(() => {
+		process.env = { ...originalEnv };
+		process.env.PROKUBE_API_URL = undefined;
+		process.env.PROKUBE_WORKSPACE = undefined;
+		process.env.PROKUBE_USER_ID = undefined;
+		process.env.PROKUBE_API_KEY = undefined;
+		process.env.KF_USER = undefined;
+		process.env.KUBERNETES_SERVICE_HOST = undefined;
+		vi.stubGlobal("fetch", vi.fn());
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		process.env = originalEnv;
+		vi.restoreAllMocks();
+	});
+
+	describe("pause", () => {
+		it("waits for Paused by default and polls the Pausing hop", async () => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse());
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
+			mockFetch.mockResolvedValueOnce(getResponse("Pausing"));
+			mockFetch.mockResolvedValueOnce(getResponse("Paused"));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			expect(sbx.status).toBe(SandboxStatus.Running);
+
+			// No arguments: the v0.7-era call site keeps its blocking semantics.
+			const pausing = sbx.pause();
+			await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+			await pausing;
+
+			expect(sbx.status).toBe(SandboxStatus.Paused);
+			expect(callsTo(mockFetch, "/sandboxes/sb-1", "GET")).toHaveLength(2);
+		});
+
+		it("returns at Pausing without polling when wait is false", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse());
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			await sbx.pause({ wait: false });
+
+			expect(sbx.status).toBe(SandboxStatus.Pausing);
+			expect(callsTo(mockFetch, "/sandboxes/sb-1", "GET")).toHaveLength(0);
+		});
+
+		it("raises the backend's lastError when the pause lands on Failed", async () => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse());
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
+			mockFetch.mockResolvedValueOnce(getResponse("Pausing"));
+			mockFetch.mockResolvedValueOnce(
+				getResponse("Failed", { lastError: "pvc snapshot rejected by CSI driver" }),
+			);
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const pausing = sbx.pause();
+			const settled = pausing.catch((error: unknown) => error);
+			await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+			const error = await settled;
+			expect(error).toBeInstanceOf(SandboxError);
+			expect(String(error)).toMatch(/failed to pause/);
+			expect(String(error)).toMatch(/pvc snapshot rejected by CSI driver/);
+			expect(String(error)).toMatch(/re-issue pause\(\)/);
+		});
+
+		it("times out when the sandbox never leaves Pausing", async () => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse());
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
+			mockFetch.mockImplementation(async () => getResponse("Pausing"));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const pausing = sbx.pause({ timeout: 3 });
+			const assertion = expect(pausing).rejects.toThrow(SandboxTimeoutError);
+			await vi.advanceTimersByTimeAsync(3000);
+			await assertion;
+			await expect(pausing).rejects.toThrow(/did not pause within 3s/);
+		});
+
+		it("stops waiting when a delete preempts the pause", async () => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse());
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
+			mockFetch.mockResolvedValueOnce(getResponse("Pausing"));
+			mockFetch.mockResolvedValueOnce(getResponse("Deleting"));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const pausing = sbx.pause();
+			const assertion = expect(pausing).rejects.toThrow(/is being deleted/);
+			await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+			await assertion;
+		});
+
+		it("surfaces a concurrent delete that finished mid-wait", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse());
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
+			mockFetch.mockResolvedValueOnce(mockResponse({ detail: "not found" }, 404));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			await expect(sbx.pause()).rejects.toThrow(/deleted while waiting/);
+		});
+
+		it("retries a stalled poll instead of failing the pause", async () => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse());
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
+			mockFetch.mockRejectedValueOnce(abortTimeoutError());
+			mockFetch.mockResolvedValueOnce(getResponse("Paused"));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const pausing = sbx.pause();
+			await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+			await pausing;
+
+			expect(sbx.status).toBe(SandboxStatus.Paused);
+		});
+
+		it("rejects a pause on a killed sandbox", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse());
+			mockFetch.mockResolvedValueOnce(new Response(null, { status: 202 }));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			await sbx.kill();
+
+			await expect(sbx.pause()).rejects.toThrow(/has been killed/);
+		});
+	});
+
+	describe("resume", () => {
+		it("does not block and reports Resuming", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse("Paused"));
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Resuming" }, 202));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			await sbx.resume();
+
+			expect(sbx.status).toBe(SandboxStatus.Resuming);
+			expect(callsTo(mockFetch, "/sandboxes/sb-1", "GET")).toHaveLength(0);
+		});
+	});
+
+	describe("waitUntilReady", () => {
+		it("polls through Resuming and warms the kernel on arrival", async () => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse("Paused"));
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Resuming" }, 202));
+			mockFetch.mockResolvedValueOnce(getResponse("Resuming"));
+			mockFetch.mockResolvedValueOnce(getResponse("Running"));
+			mockFetch.mockImplementationOnce(async (_url, init) =>
+				warmupProbeResponse((init as RequestInit).body as string),
+			);
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			await sbx.resume();
+			const ready = sbx.waitUntilReady(30);
+			await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+			await ready;
+
+			expect(sbx.status).toBe(SandboxStatus.Running);
+			expect(callsTo(mockFetch, "/sandboxes/sb-1", "GET")).toHaveLength(2);
+			// resumedFromPool is gone in v0.8, so the warmup probe always runs.
+			expect(callsTo(mockFetch, "/sandboxes/sb-1/exec", "POST")).toHaveLength(1);
+		});
+
+		it("bounds every poll GET to the remaining readiness budget", async () => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse("Pending"));
+			mockFetch.mockImplementation(async () => getResponse("Pending"));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const budgets = captureRequestTimeouts();
+
+			const ready = sbx.waitUntilReady(3);
+			const assertion = expect(ready).rejects.toThrow(SandboxTimeoutError);
+			await vi.advanceTimersByTimeAsync(3000);
+			await assertion;
+
+			// Without a per-request override each poll would inherit
+			// config.timeout (300s) and could outlast the caller's 3s budget.
+			expect(budgets.length).toBeGreaterThanOrEqual(2);
+			expect(budgets[0]).toBeLessThanOrEqual(3000);
+			expect(budgets[1]).toBeLessThanOrEqual(1000);
+			for (const [index, budget] of budgets.entries()) {
+				expect(budget).toBeLessThanOrEqual(budgets[0]);
+				if (index > 0) expect(budget).toBeLessThan(budgets[index - 1]);
+			}
+		});
+
+		it("reports SandboxTimeoutError when every poll stalls", async () => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse("Pending"));
+			mockFetch.mockRejectedValue(abortTimeoutError());
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const ready = sbx.waitUntilReady(3);
+			const assertion = expect(ready).rejects.toThrow(/did not become ready/);
+			await vi.advanceTimersByTimeAsync(3000);
+			await assertion;
+		});
+
+		it("includes lastError when the sandbox lands on Failed", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse("Pending"));
+			mockFetch.mockResolvedValueOnce(
+				getResponse("Failed", { lastError: "image pull backoff: manifest unknown" }),
+			);
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const ready = sbx.waitUntilReady(30);
+			await expect(ready).rejects.toBeInstanceOf(SandboxError);
+			await expect(ready).rejects.toThrow(/image pull backoff: manifest unknown/);
+			await expect(ready).rejects.toThrow(/terminal state/);
+		});
+
+		it("refuses a sandbox that is already being deleted", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse("Pending"));
+			mockFetch.mockResolvedValueOnce(getResponse("Deleting"));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const ready = sbx.waitUntilReady(30);
+			await expect(ready).rejects.toBeInstanceOf(SandboxError);
+			await expect(ready).rejects.toThrow(/Deleting/);
+		});
+	});
+
+	describe("kill", () => {
+		it("does not poll by default", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse());
+			mockFetch.mockResolvedValueOnce(new Response(null, { status: 202 }));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			// No arguments: unchanged v0.7 fire-and-forget shape.
+			await sbx.kill();
+
+			expect(callsTo(mockFetch, "/sandboxes/sb-1", "DELETE")).toHaveLength(1);
+			expect(callsTo(mockFetch, "/sandboxes/sb-1", "GET")).toHaveLength(0);
+			expect(sbx.status).toBe(SandboxStatus.Succeeded);
+			await expect(sbx.runCode("print(1)")).rejects.toThrow(/has been killed/);
+		});
+
+		it("polls until the backend reports the name released", async () => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse());
+			mockFetch.mockResolvedValueOnce(new Response(null, { status: 202 }));
+			mockFetch.mockResolvedValueOnce(getResponse("Deleting"));
+			mockFetch.mockResolvedValueOnce(mockResponse({ detail: "not found" }, 404));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const killing = sbx.kill({ wait: true });
+			await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+			await killing;
+
+			expect(callsTo(mockFetch, "/sandboxes/sb-1", "GET")).toHaveLength(2);
+			expect(sbx.status).toBe(SandboxStatus.Succeeded);
+			await expect(sbx.runCode("print(1)")).rejects.toThrow(/has been killed/);
+		});
+
+		it("surfaces a terminal delete failure with the backend's reason", async () => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse());
+			mockFetch.mockResolvedValueOnce(new Response(null, { status: 202 }));
+			mockFetch.mockResolvedValueOnce(getResponse("Deleting"));
+			mockFetch.mockResolvedValueOnce(
+				getResponse("Failed", { lastError: "workspace purge could not be confirmed" }),
+			);
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const settled = sbx.kill({ wait: true }).catch((error: unknown) => error);
+			await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+			const error = await settled;
+			expect(error).toBeInstanceOf(SandboxError);
+			expect(String(error)).toMatch(/failed to delete: workspace purge could not be confirmed/);
+			expect(String(error)).toMatch(/re-issue kill\(\)/);
+
+			// The delete was admitted and terminally failed: no more work, but
+			// kill() stays re-issuable.
+			await expect(sbx.runCode("print(1)")).rejects.toThrow(/is being deleted/);
+		});
+
+		it("stays deletion-locked after a wait timeout and accepts a re-issued kill", async () => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse());
+			mockFetch.mockResolvedValueOnce(new Response(null, { status: 202 }));
+			mockFetch.mockImplementation(async () => getResponse("Deleting"));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const settled = sbx.kill({ wait: true, timeout: 1 }).catch((error: unknown) => error);
+			await vi.advanceTimersByTimeAsync(1000);
+
+			const error = await settled;
+			expect(error).toBeInstanceOf(SandboxTimeoutError);
+			expect(String(error)).toMatch(/was not deleted within 1s/);
+
+			// Deletion-locked: every normal operation is refused...
+			await expect(sbx.runCode("print(1)")).rejects.toThrow(/is being deleted/);
+			expect(() => sbx.commands).toThrow(SandboxError);
+			expect(() => sbx.files).toThrow(SandboxError);
+			await expect(sbx.refresh()).rejects.toThrow(/is being deleted/);
+
+			// ...but kill() may be re-issued, and a 404 on the re-issued
+			// DELETE means the backend finished the teardown meanwhile.
+			mockFetch.mockImplementation(async () => mockResponse({ detail: "not found" }, 404));
+			await sbx.kill({ wait: true });
+			expect(sbx.status).toBe(SandboxStatus.Succeeded);
+			await expect(sbx.runCode("print(1)")).rejects.toThrow(/has been killed/);
+		});
+
+		it("treats a 404 from DELETE as the sandbox already being gone", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse());
+			mockFetch.mockResolvedValueOnce(mockResponse({ detail: "not found" }, 404));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			await sbx.kill();
+
+			expect(sbx.status).toBe(SandboxStatus.Succeeded);
+			await expect(sbx.runCode("print(1)")).rejects.toThrow(/has been killed/);
+		});
+	});
+});

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -386,6 +386,54 @@ describe("v0.8 lifecycle", () => {
 			await expect(sbx.runCode("print(1)")).rejects.toThrow(/has been killed/);
 		});
 
+		it("refuses work through helpers cached before the deletion lock engaged", async () => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse());
+			mockFetch.mockResolvedValueOnce(new Response(null, { status: 202 }));
+			mockFetch.mockImplementation(async () => getResponse("Deleting"));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			// Grab the helpers while the sandbox is still usable: the guard has
+			// to live in the helper methods, not only in the property getter.
+			const commands = sbx.commands;
+			const files = sbx.files;
+
+			const settled = sbx.kill({ wait: true, timeout: 1 }).catch((error: unknown) => error);
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(await settled).toBeInstanceOf(SandboxTimeoutError);
+
+			const deleteCalls = callsTo(mockFetch, "/sandboxes/sb-1", "DELETE").length;
+			await expect(commands.run("echo hi")).rejects.toThrow(/is being deleted/);
+			await expect(files.write("/workspace/a.txt", "hi")).rejects.toThrow(/is being deleted/);
+			await expect(files.read("/workspace/a.txt")).rejects.toThrow(/is being deleted/);
+			await expect(files.list()).rejects.toThrow(/is being deleted/);
+			await expect(files.writeBatch([{ path: "/workspace/a.txt", content: "hi" }])).rejects.toThrow(
+				/is being deleted/,
+			);
+			// Nothing reached the backend.
+			expect(callsTo(mockFetch, "/sandboxes/sb-1", "DELETE")).toHaveLength(deleteCalls);
+			expect(callsTo(mockFetch, "/sandboxes/sb-1/exec", "POST")).toHaveLength(0);
+			expect(callsTo(mockFetch, "/sandboxes/sb-1/files", "POST")).toHaveLength(0);
+		});
+
+		it("refuses work through helpers cached before kill() completed", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse());
+			mockFetch.mockResolvedValueOnce(new Response(null, { status: 202 }));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const commands = sbx.commands;
+			const files = sbx.files;
+			await sbx.kill();
+
+			await expect(commands.run("echo hi")).rejects.toThrow(/has been killed/);
+			await expect(files.list()).rejects.toThrow(/has been killed/);
+			expect(callsTo(mockFetch, "/sandboxes/sb-1/exec", "POST")).toHaveLength(0);
+		});
+
 		it("treats a 404 from DELETE as the sandbox already being gone", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValueOnce(versionResponse());

--- a/tests/live-config.test.ts
+++ b/tests/live-config.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SANDBOX_IMAGE, REQUIRED_ENV, loadLiveSandboxConfig } from "./e2e/live-config.js";
+
+/**
+ * Unit coverage for the live E2E environment contract. This file deliberately
+ * lives outside `tests/e2e/` so it runs in the normal suite: the live suite is
+ * excluded from `npm test`, but its env parsing still has to be verified in CI.
+ *
+ * Mirrors `pk-sandbox/tests/e2e/test_live_sandbox_config.py`.
+ */
+describe("loadLiveSandboxConfig", () => {
+	it("reports the required environment and applies defaults without side effects", () => {
+		const config = loadLiveSandboxConfig({});
+
+		expect(config.missingRequiredEnv).toEqual([
+			"PROKUBE_API_URL",
+			"PROKUBE_WORKSPACE",
+			"PROKUBE_API_KEY",
+		]);
+		expect(config.missingRequiredEnv).toEqual([...REQUIRED_ENV]);
+		expect(config.apiUrl).toBe("");
+		expect(config.workspace).toBe("");
+		expect(config.apiKey).toBe("");
+		expect(config.sandboxImage).toBe(DEFAULT_SANDBOX_IMAGE);
+		expect(config.poolName).toBeUndefined();
+		expect(config.poolSize).toBe(5);
+		expect(config.poolReadyTimeout).toBe(120);
+		expect(config.sdkOptions).toEqual({ apiUrl: "", workspace: "", apiKey: "" });
+	});
+
+	it("parses configured values and maps them onto SDK options", () => {
+		const config = loadLiveSandboxConfig({
+			PROKUBE_API_URL: "https://example.test/api",
+			PROKUBE_WORKSPACE: "test-workspace",
+			PROKUBE_API_KEY: "test-key",
+			SANDBOX_IMAGE: "example.test/sandbox:test",
+			SANDBOX_POOL: "test-pool",
+			SANDBOX_POOL_SIZE: "3",
+			SANDBOX_POOL_READY_TIMEOUT: "45",
+		});
+
+		expect(config.missingRequiredEnv).toEqual([]);
+		expect(config.sandboxImage).toBe("example.test/sandbox:test");
+		expect(config.poolName).toBe("test-pool");
+		expect(config.poolSize).toBe(3);
+		expect(config.poolReadyTimeout).toBe(45);
+		expect(config.sdkOptions).toEqual({
+			apiUrl: "https://example.test/api",
+			workspace: "test-workspace",
+			apiKey: "test-key",
+		});
+	});
+
+	it.each(["invalid", "0", "-1", "1.5", ""])(
+		"rejects the non-positive-integer SANDBOX_POOL_SIZE %j",
+		(value) => {
+			expect(() => loadLiveSandboxConfig({ SANDBOX_POOL_SIZE: value })).toThrow(
+				/SANDBOX_POOL_SIZE/,
+			);
+		},
+	);
+
+	it("names SANDBOX_POOL_READY_TIMEOUT when that variable is the invalid one", () => {
+		expect(() => loadLiveSandboxConfig({ SANDBOX_POOL_READY_TIMEOUT: "nope" })).toThrow(
+			"SANDBOX_POOL_READY_TIMEOUT must be a positive integer, got: nope",
+		);
+	});
+});

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -27,10 +27,10 @@ describe("SandboxStatus", () => {
 		expect(SandboxStatus.Deleting).toBe("Deleting");
 	});
 
-	it("still exposes the deprecated Bound member", () => {
-		// v0.8 backends never report it, but removing the member would break
-		// existing call sites that switch on it.
-		expect(SandboxStatus.Bound).toBe("Bound");
+	it("no longer carries the pre-0.8 Bound member", () => {
+		// Removed in 0.2.0 to match the Python SDK; v0.8 backends never
+		// report it.
+		expect("Bound" in SandboxStatus).toBe(false);
 	});
 });
 
@@ -47,8 +47,8 @@ describe("parseStatus", () => {
 		expect(parseStatus("Deleting")).toBe(SandboxStatus.Deleting);
 	});
 
-	it("still parses the legacy Bound phase", () => {
-		expect(parseStatus("Bound")).toBe(SandboxStatus.Bound);
+	it("maps the retired Bound phase to Unknown", () => {
+		expect(parseStatus("Bound")).toBe(SandboxStatus.Unknown);
 	});
 
 	it("returns Unknown for unrecognized values", () => {
@@ -137,16 +137,11 @@ describe("parseSandboxInfo", () => {
 		);
 	});
 
-	it("leaves the deprecated resumedFromPool undefined instead of throwing", () => {
-		// v0.8 stopped reporting warm-pool resume swaps. Reading the field
-		// must still be safe for existing call sites.
-		expect(
-			parseSandboxInfo({ name: "sb", phase: "Running" }, "ns").resumedFromPool,
-		).toBeUndefined();
-		expect(
-			parseSandboxInfo({ name: "sb", phase: "Running", resumedFromPool: true }, "ns")
-				.resumedFromPool,
-		).toBeUndefined();
+	it("ignores the retired resumedFromPool wire field", () => {
+		// v0.8 stopped reporting warm-pool resume swaps; the field no longer
+		// exists on SandboxInfo and stray backend payload keys are dropped.
+		const info = parseSandboxInfo({ name: "sb", phase: "Running", resumedFromPool: true }, "ns");
+		expect("resumedFromPool" in info).toBe(false);
 	});
 
 	it("honours the caller's default phase when the body has none", () => {

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -16,10 +16,21 @@ describe("SandboxStatus", () => {
 		expect(SandboxStatus.Pending).toBe("Pending");
 		expect(SandboxStatus.Running).toBe("Running");
 		expect(SandboxStatus.Paused).toBe("Paused");
-		expect(SandboxStatus.Bound).toBe("Bound");
 		expect(SandboxStatus.Succeeded).toBe("Succeeded");
 		expect(SandboxStatus.Failed).toBe("Failed");
 		expect(SandboxStatus.Unknown).toBe("Unknown");
+	});
+
+	it("exposes the v0.8 transitional phases", () => {
+		expect(SandboxStatus.Pausing).toBe("Pausing");
+		expect(SandboxStatus.Resuming).toBe("Resuming");
+		expect(SandboxStatus.Deleting).toBe("Deleting");
+	});
+
+	it("still exposes the deprecated Bound member", () => {
+		// v0.8 backends never report it, but removing the member would break
+		// existing call sites that switch on it.
+		expect(SandboxStatus.Bound).toBe("Bound");
 	});
 });
 
@@ -28,6 +39,16 @@ describe("parseStatus", () => {
 		expect(parseStatus("Running")).toBe(SandboxStatus.Running);
 		expect(parseStatus("Pending")).toBe(SandboxStatus.Pending);
 		expect(parseStatus("Paused")).toBe(SandboxStatus.Paused);
+	});
+
+	it("parses the v0.8 transitional phases", () => {
+		expect(parseStatus("Pausing")).toBe(SandboxStatus.Pausing);
+		expect(parseStatus("Resuming")).toBe(SandboxStatus.Resuming);
+		expect(parseStatus("Deleting")).toBe(SandboxStatus.Deleting);
+	});
+
+	it("still parses the legacy Bound phase", () => {
+		expect(parseStatus("Bound")).toBe(SandboxStatus.Bound);
 	});
 
 	it("returns Unknown for unrecognized values", () => {
@@ -60,7 +81,6 @@ describe("parseSandboxInfo", () => {
 				poolName: "gpu-pool",
 				createdAt: "2025-01-01T00:00:00Z",
 				autoIdleTimeoutSeconds: 1800,
-				resumedFromPool: true,
 			},
 			"my-ns",
 		);
@@ -69,13 +89,12 @@ describe("parseSandboxInfo", () => {
 		expect(info.pool).toBe("gpu-pool");
 		expect(info.createdAt).toBe("2025-01-01T00:00:00Z");
 		expect(info.autoIdleTimeoutSeconds).toBe(1800);
-		expect(info.resumedFromPool).toBe(true);
 	});
 
-	it("handles alternative field names (phase, pool, created_at, sandboxName)", () => {
+	it("handles alternative field names (phase, pool, created_at)", () => {
 		const info = parseSandboxInfo(
 			{
-				sandboxName: "alt-name",
+				name: "alt-name",
 				phase: "Paused",
 				pool: "cpu-pool",
 				created_at: "2025-06-01",
@@ -88,6 +107,56 @@ describe("parseSandboxInfo", () => {
 		expect(info.pool).toBe("cpu-pool");
 		expect(info.createdAt).toBe("2025-06-01");
 		expect(info.autoIdleTimeoutSeconds).toBe(900);
+	});
+
+	it("parses a Failed sandbox's lastError in either spelling", () => {
+		const camel = parseSandboxInfo(
+			{ name: "sb", phase: "Failed", lastError: "pvc snapshot rejected" },
+			"ns",
+		);
+		expect(camel.status).toBe(SandboxStatus.Failed);
+		expect(camel.lastError).toBe("pvc snapshot rejected");
+
+		const snake = parseSandboxInfo(
+			{ name: "sb", phase: "Failed", last_error: "workspace purge unconfirmed" },
+			"ns",
+		);
+		expect(snake.lastError).toBe("workspace purge unconfirmed");
+	});
+
+	it("leaves lastError undefined when the backend reports null or omits it", () => {
+		expect(parseSandboxInfo({ name: "sb", phase: "Running" }, "ns").lastError).toBeUndefined();
+		expect(
+			parseSandboxInfo({ name: "sb", phase: "Running", lastError: null }, "ns").lastError,
+		).toBeUndefined();
+	});
+
+	it("parses a Deleting sandbox", () => {
+		expect(parseSandboxInfo({ name: "sb", phase: "Deleting" }, "ns").status).toBe(
+			SandboxStatus.Deleting,
+		);
+	});
+
+	it("leaves the deprecated resumedFromPool undefined instead of throwing", () => {
+		// v0.8 stopped reporting warm-pool resume swaps. Reading the field
+		// must still be safe for existing call sites.
+		expect(
+			parseSandboxInfo({ name: "sb", phase: "Running" }, "ns").resumedFromPool,
+		).toBeUndefined();
+		expect(
+			parseSandboxInfo({ name: "sb", phase: "Running", resumedFromPool: true }, "ns")
+				.resumedFromPool,
+		).toBeUndefined();
+	});
+
+	it("honours the caller's default phase when the body has none", () => {
+		expect(parseSandboxInfo({ name: "sb" }, "ns", SandboxStatus.Pending).status).toBe(
+			SandboxStatus.Pending,
+		);
+	});
+
+	it("throws when the body carries no name", () => {
+		expect(() => parseSandboxInfo({ phase: "Running" }, "ns")).toThrow(/name is missing/);
 	});
 });
 

--- a/tests/pagination.test.ts
+++ b/tests/pagination.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SandboxStatus } from "../src/sandbox/models.js";
+import { Sandbox } from "../src/sandbox/sandbox.js";
+import { apiCalls, mockResponse, versionResponse } from "./helpers.js";
+
+const defaultConfig = {
+	apiUrl: "https://example.com/pkui",
+	workspace: "test-ns",
+	userId: "user@test.com",
+};
+
+const SANDBOXES_PATH = "/pkui/_platform/sandbox/test-ns/sandboxes";
+
+function listingRequest(mockFetch: { mock: { calls: unknown[][] } }): URL {
+	const calls = apiCalls(mockFetch);
+	expect(calls).toHaveLength(1);
+	return new URL(String(calls[0][0]));
+}
+
+describe("Sandbox.listPage", () => {
+	const originalEnv = process.env;
+
+	beforeEach(() => {
+		process.env = { ...originalEnv };
+		process.env.PROKUBE_API_URL = undefined;
+		process.env.PROKUBE_WORKSPACE = undefined;
+		process.env.PROKUBE_USER_ID = undefined;
+		process.env.PROKUBE_API_KEY = undefined;
+		process.env.KF_USER = undefined;
+		process.env.KUBERNETES_SERVICE_HOST = undefined;
+		vi.stubGlobal("fetch", vi.fn());
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+		vi.restoreAllMocks();
+	});
+
+	it("forwards the limit and continuation token and preserves page metadata", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValueOnce(versionResponse());
+		mockFetch.mockResolvedValueOnce(
+			mockResponse({
+				sandboxes: [{ name: "paused-1", phase: "Paused", createdAt: "2026-01-01T00:00:00Z" }],
+				loaded: 1,
+				hasMore: true,
+				continueToken: "next-token",
+			}),
+		);
+
+		const page = await Sandbox.listPage({
+			...defaultConfig,
+			limit: 10,
+			continueToken: "opaque-token",
+		});
+
+		const url = listingRequest(mockFetch);
+		expect(url.pathname).toBe(SANDBOXES_PATH);
+		expect(Object.fromEntries(url.searchParams)).toEqual({
+			limit: "10",
+			continueToken: "opaque-token",
+		});
+		expect(page.sandboxes.map((sbx) => sbx.name)).toEqual(["paused-1"]);
+		expect(page.sandboxes[0].status).toBe(SandboxStatus.Paused);
+		expect(page.loaded).toBe(1);
+		expect(page.hasMore).toBe(true);
+		expect(page.continueToken).toBe("next-token");
+	});
+
+	it("requests 25 items by default and sends no token", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValueOnce(versionResponse());
+		mockFetch.mockResolvedValueOnce(mockResponse({ sandboxes: [], loaded: 0, hasMore: false }));
+
+		const page = await Sandbox.listPage(defaultConfig);
+
+		expect(Object.fromEntries(listingRequest(mockFetch).searchParams)).toEqual({ limit: "25" });
+		expect(page.sandboxes).toEqual([]);
+		expect(page.loaded).toBe(0);
+		expect(page.hasMore).toBe(false);
+		expect(page.continueToken).toBeUndefined();
+	});
+
+	it("omits an empty continuation token, which the backend rejects with 422", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValueOnce(versionResponse());
+		mockFetch.mockResolvedValueOnce(mockResponse({ sandboxes: [], loaded: 0, hasMore: false }));
+
+		await Sandbox.listPage({ ...defaultConfig, continueToken: "" });
+
+		expect(Object.fromEntries(listingRequest(mockFetch).searchParams)).toEqual({ limit: "25" });
+	});
+
+	it.each([0, 101, -1])("rejects an out-of-range limit (%i) before any request", async (limit) => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValue(versionResponse());
+
+		await expect(Sandbox.listPage({ ...defaultConfig, limit })).rejects.toThrow(
+			/limit must be between 1 and 100/,
+		);
+		expect(apiCalls(mockFetch)).toHaveLength(0);
+	});
+
+	it("accepts the legacy {sandboxes,total} listing shape", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValueOnce(versionResponse());
+		mockFetch.mockResolvedValueOnce(
+			mockResponse({
+				sandboxes: [
+					{ name: "sb-1", status: "Running" },
+					{ name: "sb-2", status: "Pending" },
+				],
+				total: 2,
+			}),
+		);
+
+		const page = await Sandbox.listPage(defaultConfig);
+
+		expect(page.sandboxes.map((sbx) => sbx.name)).toEqual(["sb-1", "sb-2"]);
+		expect(page.loaded).toBe(2);
+		expect(page.hasMore).toBe(false);
+		expect(page.continueToken).toBeUndefined();
+	});
+
+	it("filters by phase client-side without sending a phase query param", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValueOnce(versionResponse());
+		mockFetch.mockResolvedValueOnce(
+			mockResponse({
+				sandboxes: [
+					{ name: "sb-1", phase: "Running" },
+					{ name: "sb-2", phase: "Paused" },
+					{ name: "sb-3", phase: "Pausing" },
+				],
+				loaded: 3,
+				hasMore: false,
+			}),
+		);
+
+		const page = await Sandbox.listPage({ ...defaultConfig, phase: SandboxStatus.Paused });
+
+		expect(page.sandboxes.map((sbx) => sbx.name)).toEqual(["sb-2"]);
+		expect(listingRequest(mockFetch).searchParams.has("phase")).toBe(false);
+		// `loaded`/`hasMore` describe the backend page, not the filtered view,
+		// so paging stays correct while filtering.
+		expect(page.loaded).toBe(3);
+	});
+
+	it("parses the v0.8 transitional phases and lastError on a page", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValueOnce(versionResponse());
+		mockFetch.mockResolvedValueOnce(
+			mockResponse({
+				sandboxes: [
+					{ name: "sb-1", phase: "Resuming" },
+					{ name: "sb-2", phase: "Deleting" },
+					{ name: "sb-3", phase: "Failed", lastError: "node evicted" },
+				],
+				loaded: 3,
+				hasMore: false,
+			}),
+		);
+
+		const page = await Sandbox.listPage(defaultConfig);
+
+		expect(page.sandboxes.map((sbx) => sbx.status)).toEqual([
+			SandboxStatus.Resuming,
+			SandboxStatus.Deleting,
+			SandboxStatus.Failed,
+		]);
+	});
+
+	it("checks backend compatibility once, not once per sandbox on the page", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValueOnce(versionResponse());
+		mockFetch.mockResolvedValueOnce(
+			mockResponse({
+				sandboxes: [
+					{ name: "sb-1", phase: "Running" },
+					{ name: "sb-2", phase: "Running" },
+				],
+				loaded: 2,
+				hasMore: false,
+			}),
+		);
+
+		await Sandbox.listPage(defaultConfig);
+
+		const versionCalls = mockFetch.mock.calls.filter((call) =>
+			String(call[0]).endsWith("/api/version"),
+		);
+		expect(versionCalls).toHaveLength(1);
+	});
+
+	it("gives every sandbox on the page a working client", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValueOnce(versionResponse());
+		mockFetch.mockResolvedValueOnce(
+			mockResponse({
+				sandboxes: [
+					{ name: "sb-1", phase: "Running" },
+					{ name: "sb-2", phase: "Running" },
+				],
+				loaded: 2,
+				hasMore: false,
+			}),
+		);
+
+		const page = await Sandbox.listPage(defaultConfig);
+
+		// Killing one page member must not disturb the other.
+		mockFetch.mockResolvedValueOnce(new Response(null, { status: 202 }));
+		await page.sandboxes[0].kill();
+		expect(page.sandboxes[0].status).toBe(SandboxStatus.Succeeded);
+
+		mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-2", phase: "Paused" }));
+		await page.sandboxes[1].refresh();
+		expect(page.sandboxes[1].status).toBe(SandboxStatus.Paused);
+	});
+});
+
+describe("Sandbox.list", () => {
+	const originalEnv = process.env;
+
+	beforeEach(() => {
+		process.env = { ...originalEnv };
+		process.env.PROKUBE_API_URL = undefined;
+		process.env.PROKUBE_WORKSPACE = undefined;
+		process.env.PROKUBE_USER_ID = undefined;
+		process.env.PROKUBE_API_KEY = undefined;
+		process.env.KF_USER = undefined;
+		process.env.KUBERNETES_SERVICE_HOST = undefined;
+		vi.stubGlobal("fetch", vi.fn());
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+		vi.restoreAllMocks();
+	});
+
+	it("keeps its unpaginated contract and sends no pagination params", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValueOnce(versionResponse());
+		mockFetch.mockResolvedValueOnce(
+			mockResponse({
+				sandboxes: [
+					{ name: "sb-1", status: "Running" },
+					{ name: "sb-2", status: "Paused" },
+				],
+				total: 2,
+			}),
+		);
+
+		const sandboxes = await Sandbox.list(defaultConfig);
+
+		expect(sandboxes.map((sbx) => sbx.name)).toEqual(["sb-1", "sb-2"]);
+		expect([...listingRequest(mockFetch).searchParams.keys()]).toEqual([]);
+	});
+});

--- a/tests/pool.test.ts
+++ b/tests/pool.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SandboxPool } from "../src/sandbox/pool.js";
+import { apiCalls, versionResponse } from "./helpers.js";
 
 function mockResponse(body: unknown, status = 200): Response {
 	return new Response(JSON.stringify(body), {
@@ -35,7 +36,7 @@ describe("SandboxPool", () => {
 	describe("create", () => {
 		it("creates a new pool", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse(poolData));
+			mockFetch.mockImplementation(async () => mockResponse(poolData));
 
 			const pool = await SandboxPool.create({
 				...defaultConfig,
@@ -52,7 +53,7 @@ describe("SandboxPool", () => {
 			expect(pool.cpu).toBe("2");
 			expect(pool.memory).toBe("4Gi");
 
-			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			const body = JSON.parse(apiCalls(mockFetch)[0][1]?.body as string);
 			expect(body.name).toBe("gpu-pool");
 			expect(body.image).toBe("python:3.10");
 			expect(body.poolSize).toBe(5);
@@ -60,7 +61,7 @@ describe("SandboxPool", () => {
 
 		it("omits new optional fields when not provided", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse(poolData));
+			mockFetch.mockImplementation(async () => mockResponse(poolData));
 
 			await SandboxPool.create({
 				...defaultConfig,
@@ -69,7 +70,7 @@ describe("SandboxPool", () => {
 				poolSize: 5,
 			});
 
-			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			const body = JSON.parse(apiCalls(mockFetch)[0][1]?.body as string);
 			expect(body).not.toHaveProperty("allowInternetAccess");
 			expect(body).not.toHaveProperty("autoIdleTimeoutSeconds");
 			expect(body).not.toHaveProperty("envVars");
@@ -78,7 +79,7 @@ describe("SandboxPool", () => {
 
 		it("forwards allowInternetAccess, envVars, and secretRefs to request body", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse(poolData));
+			mockFetch.mockImplementation(async () => mockResponse(poolData));
 
 			await SandboxPool.create({
 				...defaultConfig,
@@ -91,7 +92,7 @@ describe("SandboxPool", () => {
 				secretRefs: ["my-secret"],
 			});
 
-			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			const body = JSON.parse(apiCalls(mockFetch)[0][1]?.body as string);
 			expect(body.allowInternetAccess).toBe(true);
 			expect(body.envVars).toEqual([{ name: "FOO", value: "bar" }]);
 			expect(body.secretRefs).toEqual(["my-secret"]);
@@ -101,7 +102,9 @@ describe("SandboxPool", () => {
 
 		it("forwards autoIdleTimeoutSeconds to request body", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ ...poolData, autoIdleTimeoutSeconds: 1200 }));
+			mockFetch.mockImplementation(async () =>
+				mockResponse({ ...poolData, autoIdleTimeoutSeconds: 1200 }),
+			);
 
 			const pool = await SandboxPool.create({
 				...defaultConfig,
@@ -111,7 +114,7 @@ describe("SandboxPool", () => {
 				autoIdleTimeoutSeconds: 1200,
 			});
 
-			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			const body = JSON.parse(apiCalls(mockFetch)[0][1]?.body as string);
 			expect(body.autoIdleTimeoutSeconds).toBe(1200);
 			expect(pool.autoIdleTimeoutSeconds).toBe(1200);
 		});
@@ -120,7 +123,7 @@ describe("SandboxPool", () => {
 	describe("list", () => {
 		it("returns empty list", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ pools: [] }));
+			mockFetch.mockImplementation(async () => mockResponse({ pools: [] }));
 
 			const result = await SandboxPool.list(defaultConfig);
 			expect(result).toEqual([]);
@@ -128,7 +131,7 @@ describe("SandboxPool", () => {
 
 		it("returns multiple pools", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(
+			mockFetch.mockImplementation(async () =>
 				mockResponse({
 					pools: [
 						{ name: "pool-1", replicas: 3, readyReplicas: 2 },
@@ -147,7 +150,7 @@ describe("SandboxPool", () => {
 	describe("get", () => {
 		it("gets an existing pool", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse(poolData));
+			mockFetch.mockImplementation(async () => mockResponse(poolData));
 
 			const pool = await SandboxPool.get("gpu-pool", defaultConfig);
 			expect(pool.name).toBe("gpu-pool");
@@ -159,22 +162,26 @@ describe("SandboxPool", () => {
 	describe("delete", () => {
 		it("deletes the pool", async () => {
 			const mockFetch = vi.mocked(fetch);
-			// First call for get
+			// First call for version probe
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			// Second call for get
 			mockFetch.mockResolvedValueOnce(mockResponse(poolData));
-			// Second call for delete
+			// Third call for delete
 			mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
 
 			const pool = await SandboxPool.get("gpu-pool", defaultConfig);
 			await pool.delete();
 
-			expect(mockFetch.mock.calls[1][1]?.method).toBe("DELETE");
+			expect(apiCalls(mockFetch)[1][1]?.method).toBe("DELETE");
 		});
 
 		it("closes client even if delete throws", async () => {
 			const mockFetch = vi.mocked(fetch);
-			// First call for get
+			// First call for version probe
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			// Second call for get
 			mockFetch.mockResolvedValueOnce(mockResponse(poolData));
-			// Second call for delete fails
+			// Third call for delete fails
 			mockFetch.mockRejectedValueOnce(new Error("network error"));
 
 			const pool = await SandboxPool.get("gpu-pool", defaultConfig);
@@ -185,9 +192,11 @@ describe("SandboxPool", () => {
 	describe("refresh", () => {
 		it("updates pool info from API", async () => {
 			const mockFetch = vi.mocked(fetch);
-			// First call for get
+			// First call for version probe
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			// Second call for get
 			mockFetch.mockResolvedValueOnce(mockResponse(poolData));
-			// Second call for refresh with updated data
+			// Third call for refresh with updated data
 			mockFetch.mockResolvedValueOnce(
 				mockResponse({
 					name: "gpu-pool",
@@ -211,6 +220,7 @@ describe("SandboxPool", () => {
 
 		it("preserves known autoIdleTimeoutSeconds when response omits it", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ ...poolData, autoIdleTimeoutSeconds: 1200 }));
 			mockFetch.mockResolvedValueOnce(
 				mockResponse({ name: "gpu-pool", replicas: 5, readyReplicas: 5 }),

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -2,13 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PoolExhaustedError, SandboxError } from "../src/common/errors.js";
 import { SandboxStatus } from "../src/sandbox/models.js";
 import { Sandbox } from "../src/sandbox/sandbox.js";
-
-function mockResponse(body: unknown, status = 200): Response {
-	return new Response(JSON.stringify(body), {
-		status,
-		headers: { "content-type": "application/json" },
-	});
-}
+import { apiCalls, mockResponse, versionResponse, warmupProbeResponse } from "./helpers.js";
 
 const defaultConfig = {
 	apiUrl: "https://example.com/pkui",
@@ -38,7 +32,9 @@ describe("Sandbox", () => {
 	describe("fromPool", () => {
 		it("claims sandbox from pool", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ name: "sb-pool-1", status: "Running" }));
+			mockFetch.mockImplementation(async () =>
+				mockResponse({ name: "sb-pool-1", status: "Running" }),
+			);
 
 			const sbx = await Sandbox.fromPool("gpu-pool", defaultConfig);
 			expect(sbx.name).toBe("sb-pool-1");
@@ -49,14 +45,16 @@ describe("Sandbox", () => {
 			process.env.KUBERNETES_SERVICE_HOST = "10.0.0.1";
 			process.env.PROKUBE_WORKSPACE = "test-ns";
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ name: "sb-pool-1", status: "Running" }));
+			mockFetch.mockImplementation(async () =>
+				mockResponse({ name: "sb-pool-1", status: "Running" }),
+			);
 
 			const sbx = await Sandbox.fromPool("gpu-pool");
 
-			const url = mockFetch.mock.calls[0][0] as string;
-			const headers = mockFetch.mock.calls[0][1]?.headers as Record<string, string>;
+			const claim = apiCalls(mockFetch)[0];
+			const headers = claim[1]?.headers as Record<string, string>;
 			expect(sbx.name).toBe("sb-pool-1");
-			expect(url).toBe(
+			expect(String(claim[0])).toBe(
 				"http://agentgateway-proxy.agentgateway-system.svc.cluster.local/_platform/sandbox/test-ns/sandboxes/claim",
 			);
 			expect(headers["x-api-key"]).toBeUndefined();
@@ -65,36 +63,37 @@ describe("Sandbox", () => {
 
 		it("sends volumeSize when provided", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockImplementation(async () => mockResponse({ name: "sb-1", status: "Running" }));
 
 			await Sandbox.fromPool("pool", { ...defaultConfig, volumeSize: "20Gi" });
-			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			const body = JSON.parse(apiCalls(mockFetch)[0][1]?.body as string);
 			expect(body.volumeSize).toBe("20Gi");
 		});
 
 		it("sends autoIdleTimeoutSeconds when provided", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockImplementation(async () => mockResponse({ name: "sb-1", status: "Running" }));
 
 			const sbx = await Sandbox.fromPool("pool", { ...defaultConfig, autoIdleTimeoutSeconds: 900 });
-			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			const body = JSON.parse(apiCalls(mockFetch)[0][1]?.body as string);
 			expect(body.autoIdleTimeoutSeconds).toBe(900);
 			expect(sbx.autoIdleTimeoutSeconds).toBe(900);
 		});
 
 		it("surfaces retryable pool exhaustion distinctly", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(
-				new Response(
-					JSON.stringify({
-						reason: "pool_exhausted",
-						detail: "No warm pool capacity is currently available",
-					}),
-					{
-						status: 429,
-						headers: { "content-type": "application/json", "retry-after": "20" },
-					},
-				),
+			mockFetch.mockImplementation(
+				async () =>
+					new Response(
+						JSON.stringify({
+							reason: "pool_exhausted",
+							detail: "No warm pool capacity is currently available",
+						}),
+						{
+							status: 429,
+							headers: { "content-type": "application/json", "retry-after": "20" },
+						},
+					),
 			);
 
 			try {
@@ -114,7 +113,7 @@ describe("Sandbox", () => {
 	describe("create", () => {
 		it("creates sandbox with image", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ name: "my-sb", status: "Pending" }));
+			mockFetch.mockImplementation(async () => mockResponse({ name: "my-sb", status: "Pending" }));
 
 			const sbx = await Sandbox.create("python:3.10", {
 				...defaultConfig,
@@ -126,28 +125,29 @@ describe("Sandbox", () => {
 
 		it("sends volumeSize when provided", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", status: "Pending" }));
+			mockFetch.mockImplementation(async () => mockResponse({ name: "sb-1", status: "Pending" }));
 
 			await Sandbox.create("python:3.10", {
 				...defaultConfig,
 				volumeSize: "10Gi",
 			});
-			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			const body = JSON.parse(apiCalls(mockFetch)[0][1]?.body as string);
 			expect(body.volumeSize).toBe("10Gi");
 		});
 
 		it("omits new optional fields when not provided", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", status: "Pending" }));
+			mockFetch.mockImplementation(async () => mockResponse({ name: "sb-1", status: "Pending" }));
 
 			await Sandbox.create("python:3.10", {
 				...defaultConfig,
 				name: "sb-1",
 			});
 
-			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			const body = JSON.parse(apiCalls(mockFetch)[0][1]?.body as string);
 			expect(body).not.toHaveProperty("cpu");
 			expect(body).not.toHaveProperty("memory");
+			expect(body).not.toHaveProperty("resources");
 			expect(body).not.toHaveProperty("allowInternetAccess");
 			expect(body).not.toHaveProperty("autoIdleTimeoutSeconds");
 			expect(body).not.toHaveProperty("envVars");
@@ -156,7 +156,7 @@ describe("Sandbox", () => {
 
 		it("forwards resources, allowInternetAccess, envVars, and secretRefs", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", status: "Pending" }));
+			mockFetch.mockImplementation(async () => mockResponse({ name: "sb-1", status: "Pending" }));
 
 			await Sandbox.create("python:3.10", {
 				...defaultConfig,
@@ -170,9 +170,13 @@ describe("Sandbox", () => {
 				secretRefs: ["my-secret"],
 			});
 
-			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			const body = JSON.parse(apiCalls(mockFetch)[0][1]?.body as string);
+			// Both wire shapes: the internal route reads the nested `resources`
+			// object, the external API-key route reads the flat keys. Sending
+			// only one silently drops sizing on the other route.
 			expect(body.cpu).toBe("2");
 			expect(body.memory).toBe("4Gi");
+			expect(body.resources).toEqual({ cpu: "2", memory: "4Gi" });
 			expect(body.allowInternetAccess).toBe(true);
 			expect(body.envVars).toEqual([
 				{ name: "FOO", value: "bar" },
@@ -181,16 +185,31 @@ describe("Sandbox", () => {
 			expect(body.secretRefs).toEqual(["my-secret"]);
 		});
 
+		it("forwards a partially specified resources object in both shapes", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockImplementation(async () => mockResponse({ name: "sb-1", status: "Pending" }));
+
+			await Sandbox.create("python:3.10", {
+				...defaultConfig,
+				resources: { cpu: "500m" },
+			});
+
+			const body = JSON.parse(apiCalls(mockFetch)[0][1]?.body as string);
+			expect(body.cpu).toBe("500m");
+			expect(body.resources).toEqual({ cpu: "500m" });
+			expect(body).not.toHaveProperty("memory");
+		});
+
 		it("forwards autoIdleTimeoutSeconds", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ name: "sb-1", status: "Pending" }));
+			mockFetch.mockImplementation(async () => mockResponse({ name: "sb-1", status: "Pending" }));
 
 			const sbx = await Sandbox.create("python:3.10", {
 				...defaultConfig,
 				autoIdleTimeoutSeconds: 1800,
 			});
 
-			const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+			const body = JSON.parse(apiCalls(mockFetch)[0][1]?.body as string);
 			expect(body.autoIdleTimeoutSeconds).toBe(1800);
 			expect(sbx.autoIdleTimeoutSeconds).toBe(1800);
 		});
@@ -199,7 +218,7 @@ describe("Sandbox", () => {
 	describe("get / connect", () => {
 		it("gets existing sandbox", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(
+			mockFetch.mockImplementation(async () =>
 				mockResponse({
 					name: "existing-sb",
 					status: "Running",
@@ -220,7 +239,7 @@ describe("Sandbox", () => {
 	describe("list", () => {
 		it("returns empty list", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(mockResponse({ sandboxes: [], total: 0 }));
+			mockFetch.mockImplementation(async () => mockResponse({ sandboxes: [], total: 0 }));
 
 			const result = await Sandbox.list(defaultConfig);
 			expect(result).toEqual([]);
@@ -228,7 +247,7 @@ describe("Sandbox", () => {
 
 		it("returns multiple sandboxes", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(
+			mockFetch.mockImplementation(async () =>
 				mockResponse({
 					sandboxes: [
 						{ name: "sb-1", status: "Running" },
@@ -246,7 +265,7 @@ describe("Sandbox", () => {
 
 		it("filters by phase", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValue(
+			mockFetch.mockImplementation(async () =>
 				mockResponse({
 					sandboxes: [
 						{ name: "sb-1", status: "Running" },
@@ -264,12 +283,30 @@ describe("Sandbox", () => {
 			expect(result).toHaveLength(2);
 			expect(result.every((s) => s.status === SandboxStatus.Paused)).toBe(true);
 		});
+
+		it("filters by a transitional phase", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockImplementation(async () =>
+				mockResponse({
+					sandboxes: [
+						{ name: "sb-1", phase: "Pausing" },
+						{ name: "sb-2", phase: "Resuming" },
+						{ name: "sb-3", phase: "Deleting" },
+					],
+					total: 3,
+				}),
+			);
+
+			const result = await Sandbox.list({ ...defaultConfig, phase: SandboxStatus.Resuming });
+			expect(result.map((s) => s.name)).toEqual(["sb-2"]);
+		});
 	});
 
 	describe("runCode", () => {
 		it("executes code and returns result", async () => {
 			const mockFetch = vi.mocked(fetch);
 			// First call for fromPool
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			// Second call for exec
 			mockFetch.mockResolvedValueOnce(
@@ -291,6 +328,7 @@ describe("Sandbox", () => {
 
 		it("maintains session across calls", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockResolvedValueOnce(
 				mockResponse({ stdout: "", success: true, session_id: "sess-1" }),
@@ -303,12 +341,13 @@ describe("Sandbox", () => {
 			await sbx.runCode("x = 42");
 			await sbx.runCode("print(x)");
 
-			const secondExecBody = JSON.parse(mockFetch.mock.calls[2][1]?.body as string);
+			const secondExecBody = JSON.parse(apiCalls(mockFetch)[2][1]?.body as string);
 			expect(secondExecBody.session_id).toBe("sess-1");
 		});
 
 		it("reset_session sends flag", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockResolvedValueOnce(
 				mockResponse({ stdout: "", success: true, session_id: "sess-1" }),
@@ -322,7 +361,7 @@ describe("Sandbox", () => {
 			sbx.resetSession();
 			await sbx.runCode("print(1)");
 
-			const resetBody = JSON.parse(mockFetch.mock.calls[2][1]?.body as string);
+			const resetBody = JSON.parse(apiCalls(mockFetch)[2][1]?.body as string);
 			expect(resetBody.reset_session).toBe(true);
 		});
 	});
@@ -330,6 +369,7 @@ describe("Sandbox", () => {
 	describe("commands", () => {
 		it("runs shell command", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockResolvedValueOnce(
 				mockResponse({ stdout: "hello\n", stderr: "", exitCode: 0, durationMs: 50 }),
@@ -345,18 +385,20 @@ describe("Sandbox", () => {
 	describe("files", () => {
 		it("writes file", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockResolvedValueOnce(mockResponse({}));
 
 			const sbx = await Sandbox.fromPool("pool", defaultConfig);
 			await sbx.files.write("/workspace/test.txt", "hello");
 
-			const url = mockFetch.mock.calls[1][0] as string;
+			const url = apiCalls(mockFetch)[1][0] as string;
 			expect(url).toContain("/files");
 		});
 
 		it("writes multiple files in a batch", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockResolvedValueOnce(
 				mockResponse({
@@ -383,10 +425,10 @@ describe("Sandbox", () => {
 				"/workspace/b.bin",
 			]);
 
-			const url = mockFetch.mock.calls[1][0] as string;
+			const url = apiCalls(mockFetch)[1][0] as string;
 			expect(url).toContain("/files/batch");
 
-			const body = JSON.parse(mockFetch.mock.calls[1][1]?.body as string);
+			const body = JSON.parse(apiCalls(mockFetch)[1][1]?.body as string);
 			expect(body.items).toEqual([
 				{
 					path: "/workspace/a.txt",
@@ -403,6 +445,7 @@ describe("Sandbox", () => {
 
 		it("returns partial failures from batch writes", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockResolvedValueOnce(
 				mockResponse({
@@ -435,6 +478,7 @@ describe("Sandbox", () => {
 
 		it("reads file", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockResolvedValueOnce(new Response(new Uint8Array([104, 105]), { status: 200 }));
 
@@ -445,6 +489,7 @@ describe("Sandbox", () => {
 
 		it("lists files", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockResolvedValueOnce(
 				mockResponse({
@@ -462,19 +507,21 @@ describe("Sandbox", () => {
 	describe("kill", () => {
 		it("kills sandbox", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
 
 			const sbx = await Sandbox.fromPool("pool", defaultConfig);
 			await sbx.kill();
 
-			const url = mockFetch.mock.calls[1][0] as string;
+			const url = apiCalls(mockFetch)[1][0] as string;
 			expect(url).toContain("/sandboxes/sb-1");
-			expect(mockFetch.mock.calls[1][1]?.method).toBe("DELETE");
+			expect(apiCalls(mockFetch)[1][1]?.method).toBe("DELETE");
 		});
 
 		it("is idempotent", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
 
@@ -482,11 +529,12 @@ describe("Sandbox", () => {
 			await sbx.kill();
 			await sbx.kill(); // Should not throw
 			// Only one DELETE call
-			expect(mockFetch.mock.calls.filter((c) => c[1]?.method === "DELETE")).toHaveLength(1);
+			expect(apiCalls(mockFetch).filter((c) => c[1]?.method === "DELETE")).toHaveLength(1);
 		});
 
 		it("prevents further operations after kill", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
 
@@ -502,8 +550,10 @@ describe("Sandbox", () => {
 	describe("pause / resume", () => {
 		it("pauses running sandbox", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
-			mockFetch.mockResolvedValueOnce(mockResponse({}));
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Paused" }));
 
 			const sbx = await Sandbox.fromPool("pool", defaultConfig);
 			await sbx.pause();
@@ -512,23 +562,27 @@ describe("Sandbox", () => {
 
 		it("resumes paused sandbox", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
-			mockFetch.mockResolvedValueOnce(mockResponse({})); // pause
-			mockFetch.mockResolvedValueOnce(mockResponse({})); // resume
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Paused" }));
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Resuming" }, 202));
 
 			const sbx = await Sandbox.fromPool("pool", defaultConfig);
 			await sbx.pause();
 			await sbx.resume();
-			expect(sbx.status).toBe(SandboxStatus.Running);
+			// v0.8 resume is admission-only: it reports Resuming and does not
+			// block. Call waitUntilReady() to reach Running.
+			expect(sbx.status).toBe(SandboxStatus.Resuming);
 		});
 
 		it("resume preserves backend status", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
-			mockFetch.mockResolvedValueOnce(mockResponse({})); // pause
-			mockFetch.mockResolvedValueOnce(
-				mockResponse({ name: "sb-1", phase: "Pending", resumedFromPool: false }),
-			);
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Paused" }));
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pending" }, 202));
 
 			const sbx = await Sandbox.fromPool("pool", defaultConfig);
 			await sbx.pause();
@@ -538,9 +592,11 @@ describe("Sandbox", () => {
 
 		it("resume preserves known autoIdleTimeoutSeconds when response omits it", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
-			mockFetch.mockResolvedValueOnce(mockResponse({})); // pause
-			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Running" }));
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Paused" }));
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Resuming" }, 202));
 
 			const sbx = await Sandbox.fromPool("pool", { ...defaultConfig, autoIdleTimeoutSeconds: 900 });
 			await sbx.pause();
@@ -550,8 +606,9 @@ describe("Sandbox", () => {
 
 		it("pause on killed sandbox throws", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
-			mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+			mockFetch.mockResolvedValueOnce(new Response(null, { status: 202 }));
 
 			const sbx = await Sandbox.fromPool("pool", defaultConfig);
 			await sbx.kill();
@@ -562,6 +619,7 @@ describe("Sandbox", () => {
 	describe("refresh", () => {
 		it("preserves known autoIdleTimeoutSeconds when response omits it", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 
@@ -572,38 +630,15 @@ describe("Sandbox", () => {
 	});
 
 	describe("waitUntilReady", () => {
-		// Helper: respond to a probe call by echoing back the marker.
-		// The probe sends code like `print("__pk_warmup_<uuid>__")`.
-		// We parse the marker out of the request body and echo it back as
-		// stdout so the warmup loop's `stdout.trim() === marker` check passes.
-		// If the regex doesn't match we throw rather than fall back to an empty
-		// string — an empty marker would silently make the probe succeed
-		// (since both sides of `stdout.trim() === marker` would be "") and
-		// mask regressions in the probe request format.
-		function probeRespond(body: string): Response {
-			const parsed = JSON.parse(body);
-			const code = parsed.code as string;
-			const match = code.match(/print\("(__pk_warmup_[a-f0-9]+__)"\)/);
-			if (!match) {
-				throw new Error(`Unexpected probe request body: ${body}`);
-			}
-			return mockResponse({
-				stdout: `${match[1]}\n`,
-				stderr: "",
-				success: true,
-				durationMs: 5,
-				session_id: "sess-warm",
-			});
-		}
-
 		it("returns immediately if already running", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			// refresh call
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			// warmup probe call
 			mockFetch.mockImplementationOnce(async (_url, init) =>
-				probeRespond((init as RequestInit).body as string),
+				warmupProbeResponse((init as RequestInit).body as string),
 			);
 
 			const sbx = await Sandbox.fromPool("pool", defaultConfig);
@@ -612,6 +647,7 @@ describe("Sandbox", () => {
 
 		it("throws on terminal state", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Pending" }));
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Failed" }));
 
@@ -649,9 +685,11 @@ describe("Sandbox", () => {
 
 			try {
 				const mockFetch = vi.mocked(fetch);
+				mockFetch.mockResolvedValueOnce(versionResponse());
 				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
-				mockFetch.mockResolvedValueOnce(mockResponse({})); // pause
-				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pending" }));
+				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
+				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Paused" }));
+				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pending" }, 202));
 				mockFetch.mockImplementation(async () => mockResponse({ name: "sb-1", status: "Pending" }));
 
 				const sbx = await Sandbox.fromPool("pool", defaultConfig);
@@ -675,11 +713,12 @@ describe("Sandbox", () => {
 
 			try {
 				const mockFetch = vi.mocked(fetch);
+				mockFetch.mockResolvedValueOnce(versionResponse());
 				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Pending" }));
 				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Pending" }));
 				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 				mockFetch.mockImplementationOnce(async (_url, init) =>
-					probeRespond((init as RequestInit).body as string),
+					warmupProbeResponse((init as RequestInit).body as string),
 				);
 
 				const sbx = await Sandbox.create("img", { ...defaultConfig, name: "sb-1" });
@@ -695,6 +734,7 @@ describe("Sandbox", () => {
 
 		it("waitUntilReady_warms_kernel_on_cold_start", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			// create (Pending)
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Pending" }));
 			// first refresh: still Pending
@@ -713,17 +753,13 @@ describe("Sandbox", () => {
 			);
 			// second probe: marker echoed back
 			mockFetch.mockImplementationOnce(async (_url, init) =>
-				probeRespond((init as RequestInit).body as string),
+				warmupProbeResponse((init as RequestInit).body as string),
 			);
 
 			const sbx = await Sandbox.create("img", { ...defaultConfig, name: "sb-1" });
 			await sbx.waitUntilReady(30);
 
-			// Count code execution calls (probes). Exec calls are POST to /exec.
-			const execCalls = mockFetch.mock.calls.filter((c) => {
-				const url = c[0] as string;
-				return url.includes("/exec");
-			});
+			const execCalls = mockFetch.mock.calls.filter((c) => String(c[0]).includes("/exec"));
 			expect(execCalls.length).toBeGreaterThanOrEqual(2);
 			const retryBody = JSON.parse(execCalls[1][1]?.body as string);
 			expect(retryBody.session_id).toBeUndefined();
@@ -732,36 +768,37 @@ describe("Sandbox", () => {
 
 		it("waitUntilReady_warm_kernel_no_extra_latency", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			// fromPool
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			// refresh: Running
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			// single probe returning marker
 			mockFetch.mockImplementationOnce(async (_url, init) =>
-				probeRespond((init as RequestInit).body as string),
+				warmupProbeResponse((init as RequestInit).body as string),
 			);
 
 			const sbx = await Sandbox.fromPool("pool", defaultConfig);
 			await sbx.waitUntilReady(30);
 
-			const execCalls = mockFetch.mock.calls.filter((c) => {
-				const url = c[0] as string;
-				return url.includes("/exec");
-			});
-			expect(execCalls.length).toBe(1);
+			expect(mockFetch.mock.calls.filter((c) => String(c[0]).includes("/exec"))).toHaveLength(1);
 		});
 
-		it("waitUntilReady_skips_warmup_once_after_pool_resume", async () => {
+		it("always warms the kernel after a resume", async () => {
+			// v0.8 dropped the `resumedFromPool` hint, so there is no longer a
+			// "skip the warmup once" fast path: a resumed sandbox always gets a
+			// fresh pod and therefore a cold Jupyter kernel.
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
-			mockFetch.mockResolvedValueOnce(mockResponse({})); // pause
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Pausing" }, 202));
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Paused" }));
 			mockFetch.mockResolvedValueOnce(
-				mockResponse({ name: "sb-1", phase: "Running", resumedFromPool: true }),
+				mockResponse({ name: "sb-1", phase: "Running", resumedFromPool: true }, 202),
 			);
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
-			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockImplementationOnce(async (_url, init) =>
-				probeRespond((init as RequestInit).body as string),
+				warmupProbeResponse((init as RequestInit).body as string),
 			);
 
 			const sbx = await Sandbox.fromPool("pool", defaultConfig);
@@ -769,42 +806,27 @@ describe("Sandbox", () => {
 			await sbx.resume();
 			await sbx.waitUntilReady(5);
 
-			let execCalls = mockFetch.mock.calls.filter((c) => {
-				const url = c[0] as string;
-				return url.includes("/exec");
-			});
-			expect(execCalls).toHaveLength(0);
-
-			await sbx.waitUntilReady(5);
-			execCalls = mockFetch.mock.calls.filter((c) => {
-				const url = c[0] as string;
-				return url.includes("/exec");
-			});
-			expect(execCalls).toHaveLength(1);
+			expect(mockFetch.mock.calls.filter((c) => String(c[0]).includes("/exec"))).toHaveLength(1);
 		});
 
-		it("waitUntilReady_does_not_skip_warmup_for_fromPool_claim", async () => {
+		it("warms the kernel after a fromPool claim", async () => {
 			const mockFetch = vi.mocked(fetch);
-			mockFetch.mockResolvedValueOnce(
-				mockResponse({ name: "sb-1", status: "Running", resumedFromPool: true }),
-			);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockImplementationOnce(async (_url, init) =>
-				probeRespond((init as RequestInit).body as string),
+				warmupProbeResponse((init as RequestInit).body as string),
 			);
 
 			const sbx = await Sandbox.fromPool("pool", defaultConfig);
 			await sbx.waitUntilReady(5);
 
-			const execCalls = mockFetch.mock.calls.filter((c) => {
-				const url = c[0] as string;
-				return url.includes("/exec");
-			});
-			expect(execCalls).toHaveLength(1);
+			expect(mockFetch.mock.calls.filter((c) => String(c[0]).includes("/exec"))).toHaveLength(1);
 		});
 
 		it("waitUntilReady_warmup_timeout_does_not_throw", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			// fromPool
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			// refresh: Running
@@ -833,23 +855,16 @@ describe("Sandbox", () => {
 
 		it("waitUntilReady_retries_warmup_gateway_timeout", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			// fromPool
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			// refresh: Running
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			// first warmup probe times out at Agent Gateway, second succeeds
 			mockFetch.mockResolvedValueOnce(mockResponse("upstream request timeout", 504));
-			mockFetch.mockImplementationOnce(async (input, init) => {
-				const body = JSON.parse(String(init?.body ?? "{}"));
-				const match = String(body.code ?? "").match(/print\("(__pk_warmup_[a-f0-9]+__)"\)/);
-				return mockResponse({
-					stdout: `${match?.[1] ?? ""}\n`,
-					stderr: "",
-					success: true,
-					durationMs: 5,
-					session_id: "sess-warm",
-				});
-			});
+			mockFetch.mockImplementationOnce(async (_url, init) =>
+				warmupProbeResponse((init as RequestInit).body as string),
+			);
 
 			const sbx = await Sandbox.fromPool("pool", defaultConfig);
 			await expect(sbx.waitUntilReady(30)).resolves.toBeUndefined();
@@ -860,6 +875,7 @@ describe("Sandbox", () => {
 			// probe must propagate the exception rather than swallow it — that
 			// is a real failure, not a cold-kernel race.
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			// fromPool
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			// refresh: Running
@@ -875,13 +891,14 @@ describe("Sandbox", () => {
 	describe("Symbol.asyncDispose", () => {
 		it("kills sandbox on dispose", async () => {
 			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
-			mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+			mockFetch.mockResolvedValueOnce(new Response(null, { status: 202 }));
 
 			const sbx = await Sandbox.fromPool("pool", defaultConfig);
 			await sbx[Symbol.asyncDispose]();
 
-			expect(mockFetch.mock.calls.filter((c) => c[1]?.method === "DELETE")).toHaveLength(1);
+			expect(apiCalls(mockFetch).filter((c) => c[1]?.method === "DELETE")).toHaveLength(1);
 		});
 	});
 });

--- a/tests/smoke/release-consumer/index.ts
+++ b/tests/smoke/release-consumer/index.ts
@@ -1,21 +1,21 @@
 import { Config, Sandbox, commandSuccess } from "prokube";
 
 const config = new Config({
-  apiUrl: "https://example.invalid/pkui",
-  workspace: "smoke-test",
-  apiKey: "test-key",
+	apiUrl: "https://example.invalid/pkui",
+	workspace: "smoke-test",
+	apiKey: "test-key",
 });
 
 if (!config.useApiKey) {
-  throw new Error("Expected Config.useApiKey to be true");
+	throw new Error("Expected Config.useApiKey to be true");
 }
 
 if (typeof Sandbox.fromPool !== "function") {
-  throw new Error("Expected Sandbox.fromPool to be available");
+	throw new Error("Expected Sandbox.fromPool to be available");
 }
 
 if (!commandSuccess({ stdout: "", stderr: "", exitCode: 0, durationMs: 1 })) {
-  throw new Error("Expected commandSuccess helper to return true");
+	throw new Error("Expected commandSuccess helper to return true");
 }
 
 console.log("release consumer smoke test passed");

--- a/tests/smoke/release-consumer/package.json
+++ b/tests/smoke/release-consumer/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "prokube-release-consumer-smoke",
-  "private": true,
-  "type": "module",
-  "dependencies": {
-    "prokube": "file:/tmp/prokube.tgz"
-  },
-  "devDependencies": {
-    "typescript": "^5.7.0"
-  },
-  "scripts": {
-    "typecheck": "tsc --noEmit"
-  }
+	"name": "prokube-release-consumer-smoke",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"prokube": "file:/tmp/prokube.tgz"
+	},
+	"devDependencies": {
+		"typescript": "^5.7.0"
+	},
+	"scripts": {
+		"typecheck": "tsc --noEmit"
+	}
 }

--- a/tests/smoke/release-consumer/tsconfig.json
+++ b/tests/smoke/release-consumer/tsconfig.json
@@ -1,11 +1,11 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "strict": true,
-    "noEmit": true,
-    "skipLibCheck": true
-  },
-  "include": ["index.ts"]
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["index.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,11 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
 		globals: true,
+		// The live acceptance suite needs real credentials and a real cluster;
+		// it runs only via `npm run test:e2e` (vitest.e2e.config.ts).
+		exclude: [...configDefaults.exclude, "tests/e2e/**"],
 		coverage: {
 			provider: "v8",
 		},

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Live acceptance suite. Talks to a real pk-sandbox deployment, so it is never
+ * part of `npm test`; run it with `npm run test:e2e`.
+ *
+ * Sandbox lifecycle steps are slow (cold start, pause, resume, delete) and the
+ * scenarios share cluster resources, so files run one at a time and each test
+ * gets a generous budget. Coverage is off: this suite measures the backend
+ * contract, not source-line coverage.
+ */
+export default defineConfig({
+	test: {
+		globals: true,
+		include: ["tests/e2e/**/*.test.ts"],
+		fileParallelism: false,
+		sequence: { concurrent: false },
+		testTimeout: 600_000,
+		hookTimeout: 600_000,
+		teardownTimeout: 600_000,
+		coverage: { enabled: false },
+	},
+});


### PR DESCRIPTION
Brings prokube-sdk-ts to feature parity with prokube-sdk (Python) v0.2.0, targeting pk-sandbox >= 0.8.0. Ports Python commits a9c755a (readiness timeout budget), 7ab0f0f..a841894 (paginated listing), 29eaf5d..f1a934a (v0.8 async lifecycle).

## Userspace compatibility

Wire contract is breaking (backend v0.8 made every mutation 202+poll), but the TS public API is **additive/deprecating only** — every pre-0.8 export, signature, enum member, and field survives:

- `SandboxStatus.Bound`, `SandboxInfo.resumedFromPool`, `SandboxClient.resumeInfo` kept as `@deprecated`.
- `pause()` defaults to `{wait: true, timeout: 300}` (preserves v0.7 blocking call-site semantics, matching Python); `kill()` defaults to `{wait: false}` (unchanged behavior).
- `waitUntilReady` keeps its existing default timeout (`config.timeout`) instead of adopting Python's 120s.
- Guarded by `tests/api-surface.test.ts` (asserts every pre-0.8 barrel export still exists).

## Changes

- **v0.8 lifecycle**: `Pausing`/`Resuming`/`Deleting` phases; `lastError` surfacing on Failed; one shared parser for list/get/create/claim/pause/resume; `pause({wait})` polls to Paused with delete-preemption handling; `kill({wait: true})` polls to 404 (name reserved until persistence purge); deletion-locked object semantics; delete-failed surfacing; create sends resources in both wire shapes.
- **Pagination**: `Sandbox.listPage()` / `SandboxClient.listPage()` with `limit` (1-100) + `continueToken`, legacy `{sandboxes, total}` shape tolerated, explicit-token preservation.
- **Request timeouts**: `HttpClient` per-request AbortSignal budgets; readiness polls bounded to the remaining deadline; new `RequestTimeoutError`.
- **Compat check**: `MIN_BACKEND_VERSION = 0.8.0`, `GET /api/version` warn-on-stale (memoized, skipped for API-key auth; awaited in factories since TS constructors can't await).
- **CI**: new `quality.yml` (biome + tsc + vitest on PR/push) — mirrors Python's quality.yml; includes a one-time format sweep of pre-existing violations that would have failed it.
- **Release**: tag validation switched calver → semver (`v` + package.json version); version → **0.2.0**, aligned with the Python SDK. Asset flow unchanged (`prokube-v0.2.0.tgz`).
- **Docs**: README + WARM_POOL_GUIDE rewritten for async lifecycle, pagination, compat, and the version-scheme change.

## Verification

- `npm run lint` / `npm run typecheck` clean; **256/256** vitest tests across 14 files (new: lifecycle, pagination, compat, api-surface; reworked: models/http/client/sandbox/pool for the v0.8 wire contract, behaviors ported from the Python suites).
- `npm run smoke:release:npm`: 0.2.0 tarball packs, production-installs, and runs in the isolated consumer.
- Release-tag validation exercised locally: `v0.2.0` passes, `v0.2.1` and calver reject.
