### PR TITLE
fix(sandbox): accept extra stdout in kernel warmup probe

### DIFF
--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -546,11 +546,17 @@ export class Sandbox {
 	}
 
 	/**
-	 * Warm up the Jupyter kernel by running a marker print until it is
-	 * observable in stdout. Jupyter's ipykernel takes ~1.7s after pod start
-	 * before its first `execute_request` produces visible iopub stdout.
-	 * Without this, the first user `runCode` call after `waitUntilReady`
-	 * can return `success=true` with empty stdout.
+	 * Warm up the sandbox interpreter by running a marker print until the
+	 * marker appears in stdout. The first execution after pod start can race
+	 * a cold interpreter and return `success=true` with empty stdout; without
+	 * this probe, the first user `runCode` call after `waitUntilReady` would
+	 * absorb that race. (Whether the current sandbox agent still exhibits it
+	 * is unverified; the probe is kept as cheap insurance until warmup is
+	 * re-measured against it.)
+	 *
+	 * The check is containment, not equality: the interpreter may append
+	 * unrelated text (e.g. warnings) alongside the marker, and extra output
+	 * does not make the session any less live.
 	 *
 	 * Bounded by `deadline`. Never throws on deadline exceeded — logs a
 	 * warning and returns. Transient gateway timeouts during warmup are retried;
@@ -597,7 +603,7 @@ export class Sandbox {
 				await sleep(Math.min(probeIntervalMs, postErrorRemainingMs));
 				continue;
 			}
-			if (result.stdout.trim() === marker) return;
+			if (result.stdout.includes(marker)) return;
 			this._code.markSessionInvalid();
 
 			const postProbeRemainingMs = deadline - Date.now();

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -824,6 +824,33 @@ describe("Sandbox", () => {
 			expect(mockFetch.mock.calls.filter((c) => String(c[0]).includes("/exec"))).toHaveLength(1);
 		});
 
+		it("waitUntilReady_warmup_accepts_extra_stdout", async () => {
+			// Regression test for issue #51: the kernel may append unrelated
+			// warnings (e.g. IPython's history-thread SQLite error) alongside
+			// the marker. That session is live and must not be discarded.
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockImplementationOnce(async (_url, init) => {
+				const code = JSON.parse((init as RequestInit).body as string).code as string;
+				const match = code.match(/print\("(__pk_warmup_[a-f0-9]+__)"\)/);
+				if (!match) throw new Error(`Unexpected warmup probe request body: ${code}`);
+				return mockResponse({
+					stdout: `${match[1]}\nThe history saving thread hit an unexpected error (OperationalError('attempt to write a readonly database')). History will not be written to the database.\n`,
+					stderr: "",
+					success: true,
+					durationMs: 5,
+					session_id: "sess-warm",
+				});
+			});
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			await sbx.waitUntilReady(5);
+
+			expect(mockFetch.mock.calls.filter((c) => String(c[0]).includes("/exec"))).toHaveLength(1);
+		});
+
 		it("waitUntilReady_warmup_timeout_does_not_throw", async () => {
 			const mockFetch = vi.mocked(fetch);
 			mockFetch.mockResolvedValueOnce(versionResponse());


### PR DESCRIPTION
TS port of prokube/prokube-sdk#52 (robustness cleanup per the [re-scoped](https://github.com/prokube/prokube-sdk/issues/51#issuecomment-5221657907) prokube/prokube-sdk#51 — the original latency evidence was withdrawn, no performance claim is made).

`warmupKernel` required stdout to be byte-identical to its probe marker, so any extra interpreter output alongside the marker invalidated a healthy session and re-probed. A liveness probe only needs to prove the marker round-tripped:

- Comparison relaxed to containment: `result.stdout.includes(marker)`. Per-call UUID marker keeps this collision-safe; genuine cold/stale sessions still lack the marker, preserving the `markSessionInvalid()` retry path.
- Doc comment rewritten stack-agnostically: the old 'Jupyter ipykernel ~1.7s' premise described the deleted stack. Whether the cold-start race exists against the current Go sandbox agent is unverified; the probe is kept as cheap insurance until warmup is re-measured (noted in the doc comment).
- Regression test: probe stdout containing marker + extra warning text completes warmup in one `/exec` call.