### PR TITLE
feat(sandbox): long-poll waitUntilReady and single-call kernel warmup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ default, so installing from source can leave `dist/` missing unless the package
 is explicitly trusted.
 
 ```bash
-# Replace v0.2.0 with the desired release tag
-bun add https://github.com/prokube/prokube-sdk-ts/releases/download/v0.2.0/prokube-v0.2.0.tgz
+# Replace v0.3.0 with the desired release tag
+bun add https://github.com/prokube/prokube-sdk-ts/releases/download/v0.3.0/prokube-v0.3.0.tgz
 ```
 
 Each GitHub release publishes a packed `.tgz` built from the SDK's `dist/`
@@ -35,7 +35,7 @@ versions such as `2026.7.5` with release tags like `v2026-07-05`. Release tags
 are now `v` + the `package.json` version (for example `v0.2.0`), and release
 assets are named accordingly (`prokube-v0.2.0.tgz`).
 
-`0.2.0` requires a pk-sandbox backend of **0.8.0 or newer**. The SDK checks the
+`0.3.0` requires a pk-sandbox backend of **0.8.0 or newer**. The SDK checks the
 backend version on first use and emits a `console.warn` when the backend is
 older than the minimum; the check is skipped for API-key (external) access
 because external endpoints do not expose `/api/version`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prokube",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prokube",
-			"version": "0.2.0",
+			"version": "0.3.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prokube",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "TypeScript SDK for the prokube.ai sandbox platform",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/src/common/compat.ts
+++ b/src/common/compat.ts
@@ -10,7 +10,7 @@ import type { HttpClient } from "./http.js";
 export const MIN_BACKEND_VERSION = "0.8.0";
 
 /** Keep in sync with the `version` field in package.json. */
-const SDK_VERSION = "0.2.0";
+const SDK_VERSION = "0.3.0";
 
 /** Get the current SDK version. */
 export function getSdkVersion(): string {

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -295,7 +295,9 @@ export class SandboxClient {
 	 *   likewise indicate an agent without this endpoint.
 	 */
 	async pingKernel(name: string, waitTimeout: number, requestTimeout?: number): Promise<void> {
-		await this.http.get(
+		// The agent answers plain text ("pong"), not JSON: fetch bytes so the
+		// shared error translation still runs without a JSON parse of the body.
+		await this.http.getBytes(
 			this.sandboxSubPath(name, "ping"),
 			{ wait: "kernel", timeout: String(waitTimeout) },
 			requestTimeout,

--- a/src/sandbox/client.ts
+++ b/src/sandbox/client.ts
@@ -28,6 +28,17 @@ import {
 
 const textEncoder = new TextEncoder();
 
+/**
+ * Long-poll status GET (`?wait_phase=&timeout=`) tuning. The backend caps the
+ * hold at 30s and defaults to 20s; the SDK mirrors those numbers so it never
+ * asks for a window the backend would silently shorten. The margin is how
+ * much longer than the hold a request is allowed to take, covering the round
+ * trip of a response that only arrives when the hold expires.
+ */
+const DEFAULT_WAIT_TIMEOUT_SECONDS = 20;
+const MAX_WAIT_TIMEOUT_SECONDS = 30;
+const WAIT_REQUEST_MARGIN_SECONDS = 5;
+
 /** Options for one page of {@link SandboxClient.listPage}. */
 export interface ListPageOptions {
 	/** Page size, 1–100 (default: 25). */
@@ -224,10 +235,39 @@ export class SandboxClient {
 	 * @param requestTimeout Per-request timeout override in seconds. Callers
 	 *   polling toward a deadline should pass the remaining budget so a single
 	 *   stalled request cannot outlast their overall timeout.
+	 * @param waitPhase Phase to long-poll for (e.g. `Running`). When given, the
+	 *   backend holds the request open until the sandbox reaches that phase or
+	 *   its own wait window elapses, and answers with the current payload
+	 *   either way — a response that still reports another phase is a normal
+	 *   timeout, not an error. Backends that predate the parameter ignore it
+	 *   and answer immediately, which degrades to plain polling.
+	 * @param waitTimeout How long, in seconds, the backend may hold the request
+	 *   when `waitPhase` is set. Defaults to 20s and is clamped both to the
+	 *   server-side cap and to what `requestTimeout` can outlast.
 	 */
-	async get(name: string, requestTimeout?: number): Promise<SandboxInfo> {
+	async get(
+		name: string,
+		requestTimeout?: number,
+		waitPhase?: string,
+		waitTimeout?: number,
+	): Promise<SandboxInfo> {
+		let params: Record<string, string> | undefined;
+		if (waitPhase !== undefined) {
+			let hold = Math.floor(
+				Math.min(MAX_WAIT_TIMEOUT_SECONDS, waitTimeout ?? DEFAULT_WAIT_TIMEOUT_SECONDS),
+			);
+			if (requestTimeout !== undefined) {
+				// The server holds the connection for the whole wait window
+				// before answering, so the per-request timeout must outlast it.
+				// Leave a margin for the response trip so a long-poll that
+				// answers right at its cap still lands. Once too little budget
+				// is left to hold anything, fall back to a plain status GET.
+				hold = Math.min(hold, Math.floor(requestTimeout) - WAIT_REQUEST_MARGIN_SECONDS);
+			}
+			if (hold >= 1) params = { wait_phase: waitPhase, timeout: String(hold) };
+		}
 		try {
-			const data = (await this.http.get(this.sandboxPath(name), undefined, requestTimeout)) as
+			const data = (await this.http.get(this.sandboxPath(name), params, requestTimeout)) as
 				| Record<string, unknown>
 				| undefined;
 			return parseSandboxInfo(data ?? {}, this.workspace);
@@ -237,6 +277,29 @@ export class SandboxClient {
 			}
 			throw e;
 		}
+	}
+
+	/**
+	 * Block on the sandbox agent until its Jupyter kernel is warm.
+	 *
+	 * Calls `GET <sandbox>/ping?wait=kernel&timeout=<waitTimeout>` on the
+	 * sandbox agent (the same per-sandbox base path `exec` uses, so it is
+	 * proxied exactly like code execution). Resolving means the agent answered
+	 * 200 — the kernel has started.
+	 *
+	 * @throws NotFoundError if the agent (or the proxy in front of it) does not
+	 *   expose the endpoint — an older agent, so the caller must fall back to
+	 *   probing the kernel through `exec`.
+	 * @throws ProKubeError on any other non-2xx answer. `statusCode === 503`
+	 *   means the kernel is not warm yet and the call may be retried; 400/405
+	 *   likewise indicate an agent without this endpoint.
+	 */
+	async pingKernel(name: string, waitTimeout: number, requestTimeout?: number): Promise<void> {
+		await this.http.get(
+			this.sandboxSubPath(name, "ping"),
+			{ wait: "kernel", timeout: String(waitTimeout) },
+			requestTimeout,
+		);
 	}
 
 	/**

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -22,10 +22,43 @@ import {
 } from "./models.js";
 
 /**
- * Interval between lifecycle polls. Every wait in this class (readiness,
- * pause, deletion) reuses it so their pacing cannot drift apart.
+ * Interval between lifecycle polls. The pause and deletion waits reuse it so
+ * their pacing cannot drift apart. Readiness waiting long-polls instead and
+ * uses the constants below.
  */
 const POLL_INTERVAL_MS = 2000;
+
+/**
+ * Readiness waiting (see {@link Sandbox.waitUntilReady}). Each round asks the
+ * backend to hold the status GET for `LONG_POLL_WAIT_SECONDS`, allowing the
+ * request itself `LONG_POLL_MARGIN_SECONDS` more so a hold that expires still
+ * answers in time. A round that returns faster than `IMMEDIATE_RESPONSE_MS`
+ * did not block server-side, so the next one is paced by `DEGRADED_POLL_MS`.
+ */
+const LONG_POLL_WAIT_SECONDS = 20;
+const LONG_POLL_MARGIN_SECONDS = 5;
+const IMMEDIATE_RESPONSE_MS = 500;
+const DEGRADED_POLL_MS = 1000;
+
+/**
+ * Kernel warmup (see {@link Sandbox.warmupKernel}). The agent's blocking ping
+ * is bounded by `KERNEL_PING_MAX_SECONDS` per attempt; the marker probe runs
+ * with a `PROBE_MAX_TIMEOUT_SEC` budget and `PROBE_RETRY_MS` between attempts.
+ */
+const KERNEL_PING_MAX_SECONDS = 100;
+const PROBE_MAX_TIMEOUT_SEC = 5;
+const PROBE_RETRY_MS = 500;
+/**
+ * runCode and the agent ping both take an integer second budget, so a
+ * sub-second remainder cannot be expressed without overrunning the deadline.
+ */
+const MIN_PROBE_BUDGET_MS = 1000;
+
+/**
+ * Result of one kernel-ready ping attempt: the kernel is up, the agent has no
+ * such endpoint (fall back to marker probing), or the budget ran out first.
+ */
+type KernelPingOutcome = "warm" | "unsupported" | "expired";
 
 export interface SandboxOptions extends ConfigOptions {
 	volumeSize?: string;
@@ -485,8 +518,17 @@ export class Sandbox {
 	/**
 	 * Block until the sandbox phase is `Running`. Useful after `resume()`.
 	 *
-	 * Transitional phases (`Pending`, `Pausing`, `Resuming`) simply keep
-	 * polling.
+	 * Each round long-polls the status endpoint: the backend holds the GET
+	 * open until the sandbox reaches `Running` (or its own wait window
+	 * elapses) and answers with the current payload either way, so a
+	 * transition is observed within milliseconds instead of on the next fixed
+	 * poll tick. Transitional phases (`Pending`, `Pausing`, `Resuming`) simply
+	 * start another round.
+	 *
+	 * Backends that predate the `wait_phase` parameter ignore it and answer
+	 * immediately; those rounds are paced with a short client-side sleep so
+	 * the loop degrades into the plain polling it replaced instead of
+	 * hammering the API.
 	 *
 	 * @param timeout Maximum seconds to wait. Defaults to the configured
 	 *   request timeout.
@@ -502,20 +544,29 @@ export class Sandbox {
 		const deadline = Date.now() + effectiveTimeout * 1000;
 
 		while (true) {
-			let remainingMs = deadline - Date.now();
+			const roundStarted = Date.now();
+			let remainingMs = deadline - roundStarted;
 			if (remainingMs <= 0) break;
+			// Ask the backend to hold the request for at most the remaining
+			// budget, and cap the GET itself at the remaining budget too so a
+			// single stalled round cannot block past the caller's deadline:
+			// without this the request falls back to the client's default
+			// timeout (PROKUBE_TIMEOUT, 300s), which can vastly exceed a short
+			// waitUntilReady(timeout) call. The GET is allowed a margin over
+			// the hold so a response that only arrives when the hold expires
+			// is not mistaken for a stall.
+			const waitTimeoutSec = Math.min(LONG_POLL_WAIT_SECONDS, remainingMs / 1000);
 			try {
-				// Cap the GET at the remaining budget so a single stalled poll
-				// cannot block past the caller's deadline: without this the
-				// request falls back to the client's default timeout
-				// (PROKUBE_TIMEOUT, 300s), which can vastly exceed a short
-				// waitUntilReady(timeout) call.
-				await this.refresh(remainingMs / 1000);
+				await this.refresh(
+					Math.min(waitTimeoutSec + LONG_POLL_MARGIN_SECONDS, remainingMs / 1000),
+					SandboxStatus.Running,
+					waitTimeoutSec,
+				);
 			} catch (e) {
 				if (!(e instanceof RequestTimeoutError)) throw e;
 				remainingMs = deadline - Date.now();
 				if (remainingMs <= 0) break;
-				await sleep(Math.min(POLL_INTERVAL_MS, remainingMs));
+				await sleep(Math.min(DEGRADED_POLL_MS, remainingMs));
 				continue;
 			}
 
@@ -535,9 +586,16 @@ export class Sandbox {
 				);
 			}
 
-			remainingMs = deadline - Date.now();
+			const roundEnded = Date.now();
+			remainingMs = deadline - roundEnded;
 			if (remainingMs <= 0) break;
-			await sleep(Math.min(POLL_INTERVAL_MS, remainingMs));
+			if (roundEnded - roundStarted < IMMEDIATE_RESPONSE_MS) {
+				// The answer came back instantly without the target phase, so
+				// the backend did not hold the request — either it ignores
+				// wait_phase (older backend) or it reported an intermediate
+				// transition. Pace the next round instead of spinning.
+				await sleep(Math.min(DEGRADED_POLL_MS, remainingMs));
+			}
 		}
 
 		throw new SandboxTimeoutError(
@@ -546,50 +604,123 @@ export class Sandbox {
 	}
 
 	/**
-	 * Warm up the sandbox interpreter by running a marker print until the
-	 * marker appears in stdout. The first execution after pod start can race
-	 * a cold interpreter and return `success=true` with empty stdout; without
-	 * this probe, the first user `runCode` call after `waitUntilReady` would
-	 * absorb that race. (Whether the current sandbox agent still exhibits it
-	 * is unverified; the probe is kept as cheap insurance until warmup is
-	 * re-measured against it.)
+	 * Wait until the sandbox's code-execution pipeline is live.
 	 *
-	 * The check is containment, not equality: the interpreter may append
-	 * unrelated text (e.g. warnings) alongside the marker, and extra output
-	 * does not make the session any less live.
+	 * The first execution after pod start can race a cold interpreter and
+	 * return `success=true` with empty stdout; without warmup, the first user
+	 * `runCode` call after `waitUntilReady` would absorb that race. (Whether
+	 * the current sandbox agent still exhibits it is unverified; the probe is
+	 * kept as cheap insurance until warmup is re-measured against it.)
+	 *
+	 * The agent closes that window itself: `GET <sandbox>/ping?wait=kernel`
+	 * blocks until the kernel has started (200) or the wait window elapses
+	 * (503). One blocking call therefore replaces the poll loop. Because the
+	 * ping only proves the *kernel* started — not that the exec/SSE pipeline
+	 * in front of it delivers output — a `print(<marker>)` round-trip still
+	 * follows it as end-to-end proof, run by {@link probeKernelLoop}: a warm
+	 * kernel normally echoes the marker on the first try, but a transient
+	 * gateway 504 or a swallowed first stdout must be retried inside the
+	 * remaining budget instead of handing the user a sandbox whose next
+	 * `runCode` resets the just-prewarmed session. The marker check is
+	 * containment, not equality: the interpreter may append unrelated text
+	 * (e.g. warnings) alongside the marker, and extra output does not make
+	 * the session any less live.
+	 *
+	 * Agents without the endpoint answer 404/400/405; those fall back to the
+	 * very same loop, which is all warmup was before the ping existed.
 	 *
 	 * Bounded by `deadline`. Never throws on deadline exceeded — logs a
-	 * warning and returns. Transient gateway timeouts during warmup are retried;
-	 * other errors from `runCode` still propagate.
+	 * warning and returns. Other errors from `runCode` still propagate.
 	 */
 	private async warmupKernel(deadline: number): Promise<void> {
 		this.checkUsable();
+		const outcome = await this.pingKernel(deadline);
+		if (outcome === "expired") {
+			this.warnWarmupIncomplete(0);
+			return;
+		}
+		await this.probeKernelLoop(deadline);
+	}
+
+	/**
+	 * Block on the agent's kernel-ready ping until it reports warm.
+	 *
+	 * Resolves to `"warm"` once the agent answers 200, `"unsupported"` if it
+	 * has no such endpoint (so the caller must probe through `exec`), or
+	 * `"expired"` when the deadline runs out while the kernel is still cold.
+	 */
+	private async pingKernel(deadline: number): Promise<KernelPingOutcome> {
+		while (true) {
+			const remainingMs = deadline - Date.now();
+			// The agent takes an integer second wait window, so a sub-second
+			// budget cannot be expressed; give up rather than round up and
+			// overrun waitUntilReady's deadline.
+			if (remainingMs < MIN_PROBE_BUDGET_MS) return "expired";
+			// Keep the agent's own wait window inside the remaining budget,
+			// leaving room for the response trip, and below the ceiling the
+			// gateway in front of the agent tolerates.
+			const waitSeconds = Math.floor(
+				Math.min(
+					KERNEL_PING_MAX_SECONDS,
+					Math.max(1, remainingMs / 1000 - LONG_POLL_MARGIN_SECONDS),
+				),
+			);
+			const started = Date.now();
+			try {
+				await this._client.pingKernel(this._name, waitSeconds, remainingMs / 1000);
+			} catch (error) {
+				// A stalled ping is indistinguishable from a proxy that never
+				// forwards it; the marker probe is the reliable path.
+				if (error instanceof RequestTimeoutError) return "unsupported";
+				if (error instanceof NotFoundError) return "unsupported";
+				if (!(error instanceof ProKubeError)) throw error;
+				if (error.statusCode === 400 || error.statusCode === 405) return "unsupported";
+				if (error.statusCode !== 503 && error.statusCode !== 504) throw error;
+				// 503: kernel still cold after the agent's wait window.
+				// 504: the gateway cut the blocking request. Both are
+				// transient — keep waiting inside our own deadline, pacing a
+				// ping that answered instantly so a non-blocking agent cannot
+				// spin the loop.
+				if (Date.now() - started < IMMEDIATE_RESPONSE_MS) {
+					await sleep(Math.min(PROBE_RETRY_MS, Math.max(0, deadline - Date.now())));
+				}
+				continue;
+			}
+			return "warm";
+		}
+	}
+
+	/**
+	 * Probe the Jupyter kernel until it echoes a unique marker back.
+	 *
+	 * Used both as the end-to-end proof after a warm kernel-ready ping and as
+	 * the whole warmup for agents without that endpoint. The marker is
+	 * per-call to avoid collisions with user code, and a probe that returns
+	 * without it discards the session before retrying — otherwise a
+	 * cold/stale Jupyter session can be reused forever and every probe keeps
+	 * returning empty stdout.
+	 */
+	private async probeKernelLoop(deadline: number): Promise<void> {
 		const marker = `__pk_warmup_${randomUUID().replace(/-/g, "")}__`;
 		const probeCode = `print("${marker}")`;
-		const probeIntervalMs = 500;
-		// runCode expects a positive integer second timeout. We can't probe
-		// with a sub-second budget without potentially overrunning the
-		// deadline, so once less than 1s remains we give up rather than
-		// rounding up.
-		const minProbeBudgetMs = 1000;
-		// Cap the per-probe backend timeout so a single warmup attempt
-		// cannot consume the entire waitUntilReady budget. Without this
-		// cap, the first probe call against an unresponsive kernel could
-		// block the SDK for the user's full timeout (potentially minutes)
-		// and starve the intended 500ms retry loop.
-		const maxProbeTimeoutSec = 5;
+		let attempts = 0;
 
 		while (true) {
 			const remainingMs = deadline - Date.now();
-			if (remainingMs < minProbeBudgetMs) break;
+			// runCode expects a positive integer second timeout. We can't
+			// probe with a sub-second budget without potentially overrunning
+			// the deadline, so once less than 1s remains we give up rather
+			// than rounding up.
+			if (remainingMs < MIN_PROBE_BUDGET_MS) break;
+			attempts += 1;
 
 			// `probeTimeoutSec` caps the BACKEND execution time of the probe
-			// (passed through to /exec). The client-side fetch is bounded
-			// separately by the HTTP client's configured timeout, so a stalled
-			// connection can still let one probe outlive this deadline — that
-			// bound is config.timeout, not infinity. floor() at least
-			// guarantees probeTimeoutSec * 1000 <= remainingMs.
-			const probeTimeoutSec = Math.min(maxProbeTimeoutSec, Math.floor(remainingMs / 1000));
+			// (passed through to /exec), keeping retries frequent against a
+			// stuck kernel. Without this cap the first probe call could block
+			// the SDK for the user's full timeout (potentially minutes) and
+			// starve the retry loop. floor() at least guarantees
+			// probeTimeoutSec * 1000 <= remainingMs.
+			const probeTimeoutSec = Math.min(PROBE_MAX_TIMEOUT_SEC, Math.floor(remainingMs / 1000));
 			let result: CodeResult;
 			try {
 				result = await this.runCode(probeCode, "python", probeTimeoutSec);
@@ -600,7 +731,7 @@ export class Sandbox {
 				this._code.markSessionInvalid();
 				const postErrorRemainingMs = deadline - Date.now();
 				if (postErrorRemainingMs <= 0) break;
-				await sleep(Math.min(probeIntervalMs, postErrorRemainingMs));
+				await sleep(Math.min(PROBE_RETRY_MS, postErrorRemainingMs));
 				continue;
 			}
 			if (result.stdout.includes(marker)) return;
@@ -608,11 +739,16 @@ export class Sandbox {
 
 			const postProbeRemainingMs = deadline - Date.now();
 			if (postProbeRemainingMs <= 0) break;
-			await sleep(Math.min(probeIntervalMs, postProbeRemainingMs));
+			await sleep(Math.min(PROBE_RETRY_MS, postProbeRemainingMs));
 		}
 
+		this.warnWarmupIncomplete(attempts);
+	}
+
+	/** Log that warmup did not confirm a live kernel; never throws. */
+	private warnWarmupIncomplete(attempts: number): void {
 		console.warn(
-			`Sandbox '${this._name}': kernel warmup probe did not observe marker within deadline; proceeding anyway`,
+			`Sandbox '${this._name}': kernel warmup probe did not observe marker within deadline after ${attempts} attempt(s); proceeding anyway`,
 		);
 	}
 
@@ -705,10 +841,13 @@ export class Sandbox {
 	 *
 	 * @param requestTimeout Per-request timeout override in seconds. Callers
 	 *   polling toward a deadline should pass the remaining budget.
+	 * @param waitPhase Phase to long-poll for. See {@link SandboxClient.get}.
+	 * @param waitTimeout How long the backend may hold the request when
+	 *   `waitPhase` is set. See {@link SandboxClient.get}.
 	 */
-	async refresh(requestTimeout?: number): Promise<void> {
+	async refresh(requestTimeout?: number, waitPhase?: string, waitTimeout?: number): Promise<void> {
 		this.checkUsable();
-		const info = await this._client.get(this._name, requestTimeout);
+		const info = await this._client.get(this._name, requestTimeout, waitPhase, waitTimeout);
 		this._status = info.status;
 		this._lastError = info.lastError;
 		if (info.image) this._image = info.image;

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -80,8 +80,15 @@ export function warmupProbeResponse(requestBody: string): Response {
  * Defaults to 404 because that is what every pre-#107 agent answers.
  */
 export function pingResponse(status = 404): Response {
-	const body = status === 200 ? { status: "ok" } : { detail: "not found" };
-	return mockResponse(body, status);
+	// The real agent answers plain text ("pong"), not JSON — the mock pins
+	// that so the client can never regress into parsing the ping body.
+	if (status === 200) {
+		return new Response("pong", {
+			status: 200,
+			headers: { "content-type": "text/plain; charset=utf-8" },
+		});
+	}
+	return mockResponse({ detail: "not found" }, status);
 }
 
 /**

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -72,6 +72,19 @@ export function warmupProbeResponse(requestBody: string): Response {
 }
 
 /**
+ * Answer the agent's kernel-ready ping (`GET <sandbox>/ping?wait=kernel`).
+ *
+ * `waitUntilReady` calls it once before the marker probe: 200 means the
+ * kernel started, 503 means it is still cold (retry), and 400/404/405 mean the
+ * agent predates the endpoint, so warmup falls back to the probe loop alone.
+ * Defaults to 404 because that is what every pre-#107 agent answers.
+ */
+export function pingResponse(status = 404): Response {
+	const body = status === 200 ? { status: "ok" } : { detail: "not found" };
+	return mockResponse(body, status);
+}
+
+/**
  * Reject the way `AbortSignal.timeout` does, so `HttpClient` can map it onto
  * `RequestTimeoutError` (the TS stand-in for `httpx.TimeoutException`).
  */

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -3,10 +3,12 @@ import { SandboxError, SandboxTimeoutError } from "../src/common/errors.js";
 import { SandboxStatus } from "../src/sandbox/models.js";
 import { Sandbox } from "../src/sandbox/sandbox.js";
 import {
+	type FetchCall,
 	abortTimeoutError,
 	callsTo,
 	captureRequestTimeouts,
 	mockResponse,
+	pingResponse,
 	versionResponse,
 	warmupProbeResponse,
 } from "./helpers.js";
@@ -30,11 +32,27 @@ function getResponse(phase: string, extra: Record<string, unknown> = {}): Respon
 }
 
 /**
- * The sandbox lifecycle is a poll loop with a 2s interval, so every test that
+ * The pause and deletion waits poll on a 2s interval, so every test that
  * exercises more than one poll drives fake timers. Advancing exactly
  * `(polls - 1) * 2000` keeps the queued response list and the loop in step.
  */
 const POLL_INTERVAL_MS = 2000;
+
+/**
+ * Readiness waiting long-polls instead, and paces a round the backend
+ * answered instantly (an old backend ignoring `wait_phase`) by 1s.
+ */
+const DEGRADED_POLL_MS = 1000;
+
+/** Query parameters of a recorded call. */
+function queryOf(call: FetchCall): URLSearchParams {
+	return new URL(String(call[0])).searchParams;
+}
+
+/** Recorded status GETs, in order (the long-poll query is not part of the path). */
+function statusGets(mockFetch: { mock: { calls: unknown[][] } }): FetchCall[] {
+	return callsTo(mockFetch, "/sandboxes/sb-1", "GET");
+}
 
 describe("v0.8 lifecycle", () => {
 	const originalEnv = process.env;
@@ -211,6 +229,7 @@ describe("v0.8 lifecycle", () => {
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", phase: "Resuming" }, 202));
 			mockFetch.mockResolvedValueOnce(getResponse("Resuming"));
 			mockFetch.mockResolvedValueOnce(getResponse("Running"));
+			mockFetch.mockResolvedValueOnce(pingResponse());
 			mockFetch.mockImplementationOnce(async (_url, init) =>
 				warmupProbeResponse((init as RequestInit).body as string),
 			);
@@ -218,7 +237,7 @@ describe("v0.8 lifecycle", () => {
 			const sbx = await Sandbox.fromPool("pool", defaultConfig);
 			await sbx.resume();
 			const ready = sbx.waitUntilReady(30);
-			await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+			await vi.advanceTimersByTimeAsync(DEGRADED_POLL_MS);
 			await ready;
 
 			expect(sbx.status).toBe(SandboxStatus.Running);
@@ -241,12 +260,11 @@ describe("v0.8 lifecycle", () => {
 			const assertion = expect(ready).rejects.toThrow(SandboxTimeoutError);
 			await vi.advanceTimersByTimeAsync(3000);
 			await assertion;
-
 			// Without a per-request override each poll would inherit
 			// config.timeout (300s) and could outlast the caller's 3s budget.
 			expect(budgets.length).toBeGreaterThanOrEqual(2);
 			expect(budgets[0]).toBeLessThanOrEqual(3000);
-			expect(budgets[1]).toBeLessThanOrEqual(1000);
+			expect(budgets[budgets.length - 1]).toBeLessThanOrEqual(1000);
 			for (const [index, budget] of budgets.entries()) {
 				expect(budget).toBeLessThanOrEqual(budgets[0]);
 				if (index > 0) expect(budget).toBeLessThan(budgets[index - 1]);
@@ -292,6 +310,216 @@ describe("v0.8 lifecycle", () => {
 			const ready = sbx.waitUntilReady(30);
 			await expect(ready).rejects.toBeInstanceOf(SandboxError);
 			await expect(ready).rejects.toThrow(/Deleting/);
+		});
+	});
+
+	describe("waitUntilReady long-poll", () => {
+		it("asks the backend to hold the status GET until Running", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse("Pending"));
+			mockFetch.mockResolvedValueOnce(getResponse("Running"));
+			mockFetch.mockResolvedValueOnce(pingResponse(200));
+			mockFetch.mockImplementationOnce(async (_url, init) =>
+				warmupProbeResponse((init as RequestInit).body as string),
+			);
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const budgets = captureRequestTimeouts();
+			await sbx.waitUntilReady(100);
+
+			const [statusGet] = statusGets(mockFetch);
+			expect(queryOf(statusGet).get("wait_phase")).toBe("Running");
+			// The backend caps its hold at 30s; the SDK never asks for a
+			// window the backend would silently shorten.
+			expect(queryOf(statusGet).get("timeout")).toBe("20");
+			// The request must outlast the server-side hold, otherwise a
+			// long-poll answering at its cap looks like a stalled request.
+			expect(budgets[0]).toBeGreaterThan(20_000);
+		});
+
+		it("clamps the hold to the remaining readiness budget", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse("Pending"));
+			mockFetch.mockResolvedValueOnce(getResponse("Running"));
+			mockFetch.mockResolvedValueOnce(pingResponse(200));
+			mockFetch.mockImplementationOnce(async (_url, init) =>
+				warmupProbeResponse((init as RequestInit).body as string),
+			);
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const budgets = captureRequestTimeouts();
+			await sbx.waitUntilReady(10);
+
+			const hold = Number(queryOf(statusGets(mockFetch)[0]).get("timeout"));
+			// A 10s budget leaves 5s of hold once the response margin is
+			// reserved — the hold shrinks, not just the request timeout.
+			expect(hold).toBeGreaterThanOrEqual(1);
+			expect(hold).toBeLessThanOrEqual(5);
+			expect(budgets[0]).toBeLessThanOrEqual(10_000);
+			expect(hold * 1000).toBeLessThan(budgets[0]);
+		});
+
+		it("sends a plain GET when nothing is left to hold", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse("Pending"));
+			mockFetch.mockResolvedValueOnce(getResponse("Running"));
+			mockFetch.mockResolvedValueOnce(pingResponse(200));
+			mockFetch.mockImplementationOnce(async (_url, init) =>
+				warmupProbeResponse((init as RequestInit).body as string),
+			);
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			await sbx.waitUntilReady(3);
+
+			expect([...queryOf(statusGets(mockFetch)[0]).keys()]).toEqual([]);
+		});
+
+		it("paces an instant round that did not report the target phase", async () => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse("Pending"));
+			mockFetch.mockResolvedValueOnce(getResponse("Pending"));
+			mockFetch.mockResolvedValueOnce(getResponse("Running"));
+			mockFetch.mockResolvedValueOnce(pingResponse(200));
+			mockFetch.mockImplementationOnce(async (_url, init) =>
+				warmupProbeResponse((init as RequestInit).body as string),
+			);
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const ready = sbx.waitUntilReady(30);
+			let settled = false;
+			void ready.then(() => {
+				settled = true;
+			});
+
+			// An old backend ignores wait_phase and answers at once; without
+			// client-side pacing the loop would spin as fast as the network.
+			await vi.advanceTimersByTimeAsync(DEGRADED_POLL_MS - 1);
+			expect(settled).toBe(false);
+			expect(statusGets(mockFetch)).toHaveLength(1);
+
+			await vi.advanceTimersByTimeAsync(1);
+			await ready;
+			expect(statusGets(mockFetch)).toHaveLength(2);
+			expect(sbx.status).toBe(SandboxStatus.Running);
+		});
+	});
+
+	describe("kernel warmup ping", () => {
+		it("converges in one marker run when the ping reports the kernel warm", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse("Pending"));
+			mockFetch.mockResolvedValueOnce(getResponse("Running"));
+			mockFetch.mockResolvedValueOnce(pingResponse(200));
+			mockFetch.mockImplementationOnce(async (_url, init) =>
+				warmupProbeResponse((init as RequestInit).body as string),
+			);
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			await sbx.waitUntilReady(300);
+
+			const [ping] = callsTo(mockFetch, "/sandboxes/sb-1/ping", "GET");
+			expect(queryOf(ping).get("wait")).toBe("kernel");
+			// A huge readiness budget must not park a request on the agent
+			// forever: the wait window is capped at 100s.
+			expect(queryOf(ping).get("timeout")).toBe("100");
+			// The ping already proved the kernel is warm, so the marker
+			// verification converges on its first round-trip.
+			expect(callsTo(mockFetch, "/sandboxes/sb-1/exec", "POST")).toHaveLength(1);
+		});
+
+		it("shrinks the ping wait window with the remaining budget", async () => {
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse("Pending"));
+			mockFetch.mockResolvedValueOnce(getResponse("Running"));
+			mockFetch.mockResolvedValueOnce(pingResponse(200));
+			mockFetch.mockImplementationOnce(async (_url, init) =>
+				warmupProbeResponse((init as RequestInit).body as string),
+			);
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const budgets = captureRequestTimeouts();
+			await sbx.waitUntilReady(10);
+
+			const [ping] = callsTo(mockFetch, "/sandboxes/sb-1/ping", "GET");
+			const waitSeconds = Number(queryOf(ping).get("timeout"));
+			// The agent may never block past the caller's own deadline.
+			expect(waitSeconds).toBeGreaterThanOrEqual(1);
+			expect(waitSeconds).toBeLessThanOrEqual(5);
+			// budgets[0] is the status GET, budgets[1] the ping.
+			expect(budgets[1]).toBeLessThanOrEqual(10_000);
+		});
+
+		it.each([400, 404, 405])("falls back to the probe loop on ping %i", async (status) => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse("Pending"));
+			mockFetch.mockResolvedValueOnce(getResponse("Running"));
+			mockFetch.mockResolvedValueOnce(pingResponse(status));
+			// Cold kernel on the first probe, warm on the retry.
+			mockFetch.mockResolvedValueOnce(
+				mockResponse({ stdout: "", stderr: "", success: true, durationMs: 1 }),
+			);
+			mockFetch.mockImplementationOnce(async (_url, init) =>
+				warmupProbeResponse((init as RequestInit).body as string),
+			);
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const ready = sbx.waitUntilReady(60);
+			await vi.advanceTimersByTimeAsync(500);
+			await ready;
+
+			expect(callsTo(mockFetch, "/sandboxes/sb-1/ping", "GET")).toHaveLength(1);
+			// An agent without the endpoint keeps the retrying marker probe.
+			expect(callsTo(mockFetch, "/sandboxes/sb-1/exec", "POST")).toHaveLength(2);
+		});
+
+		it("retries a 503 ping inside the deadline", async () => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse("Pending"));
+			mockFetch.mockResolvedValueOnce(getResponse("Running"));
+			mockFetch.mockResolvedValueOnce(pingResponse(503));
+			mockFetch.mockResolvedValueOnce(pingResponse(200));
+			mockFetch.mockImplementationOnce(async (_url, init) =>
+				warmupProbeResponse((init as RequestInit).body as string),
+			);
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const ready = sbx.waitUntilReady(60);
+			// 503 means "still cold": the instant answer is paced, then retried.
+			await vi.advanceTimersByTimeAsync(500);
+			await ready;
+
+			expect(callsTo(mockFetch, "/sandboxes/sb-1/ping", "GET")).toHaveLength(2);
+			expect(callsTo(mockFetch, "/sandboxes/sb-1/exec", "POST")).toHaveLength(1);
+		});
+
+		it("warns and returns when the budget expires before the kernel is warm", async () => {
+			vi.useFakeTimers();
+			const mockFetch = vi.mocked(fetch);
+			mockFetch.mockResolvedValueOnce(versionResponse());
+			mockFetch.mockResolvedValueOnce(claimResponse("Pending"));
+			mockFetch.mockResolvedValueOnce(getResponse("Running"));
+			mockFetch.mockImplementation(async () => pingResponse(503));
+
+			const sbx = await Sandbox.fromPool("pool", defaultConfig);
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const ready = sbx.waitUntilReady(2);
+			await vi.advanceTimersByTimeAsync(2000);
+
+			// Warmup never throws: the sandbox is up, only its kernel is unproven.
+			await expect(ready).resolves.toBeUndefined();
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/did not observe marker/));
+			expect(callsTo(mockFetch, "/sandboxes/sb-1/exec", "POST")).toHaveLength(0);
 		});
 	});
 

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -846,6 +846,7 @@ describe("Sandbox", () => {
 			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockResolvedValueOnce(pingResponse());
 			mockFetch.mockImplementationOnce(async (_url, init) => {
 				const code = JSON.parse((init as RequestInit).body as string).code as string;
 				const match = code.match(/print\("(__pk_warmup_[a-f0-9]+__)"\)/);

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PoolExhaustedError, SandboxError } from "../src/common/errors.js";
 import { SandboxStatus } from "../src/sandbox/models.js";
 import { Sandbox } from "../src/sandbox/sandbox.js";
-import { apiCalls, mockResponse, versionResponse, warmupProbeResponse } from "./helpers.js";
+import {
+	apiCalls,
+	mockResponse,
+	pingResponse,
+	versionResponse,
+	warmupProbeResponse,
+} from "./helpers.js";
 
 const defaultConfig = {
 	apiUrl: "https://example.com/pkui",
@@ -636,6 +642,8 @@ describe("Sandbox", () => {
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			// refresh call
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			// kernel-ready ping: this agent has no such endpoint
+			mockFetch.mockResolvedValueOnce(pingResponse());
 			// warmup probe call
 			mockFetch.mockImplementationOnce(async (_url, init) =>
 				warmupProbeResponse((init as RequestInit).body as string),
@@ -717,6 +725,7 @@ describe("Sandbox", () => {
 				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Pending" }));
 				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Pending" }));
 				mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+				mockFetch.mockResolvedValueOnce(pingResponse());
 				mockFetch.mockImplementationOnce(async (_url, init) =>
 					warmupProbeResponse((init as RequestInit).body as string),
 				);
@@ -741,6 +750,8 @@ describe("Sandbox", () => {
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Pending" }));
 			// second refresh: Running
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			// kernel-ready ping: unsupported, so warmup probes through exec
+			mockFetch.mockResolvedValueOnce(pingResponse());
 			// first probe: empty stdout (kernel cold)
 			mockFetch.mockResolvedValueOnce(
 				mockResponse({
@@ -773,6 +784,7 @@ describe("Sandbox", () => {
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			// refresh: Running
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockResolvedValueOnce(pingResponse());
 			// single probe returning marker
 			mockFetch.mockImplementationOnce(async (_url, init) =>
 				warmupProbeResponse((init as RequestInit).body as string),
@@ -797,6 +809,7 @@ describe("Sandbox", () => {
 				mockResponse({ name: "sb-1", phase: "Running", resumedFromPool: true }, 202),
 			);
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockResolvedValueOnce(pingResponse());
 			mockFetch.mockImplementationOnce(async (_url, init) =>
 				warmupProbeResponse((init as RequestInit).body as string),
 			);
@@ -814,6 +827,7 @@ describe("Sandbox", () => {
 			mockFetch.mockResolvedValueOnce(versionResponse());
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockResolvedValueOnce(pingResponse());
 			mockFetch.mockImplementationOnce(async (_url, init) =>
 				warmupProbeResponse((init as RequestInit).body as string),
 			);
@@ -887,6 +901,7 @@ describe("Sandbox", () => {
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			// refresh: Running
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockResolvedValueOnce(pingResponse());
 			// first warmup probe times out at Agent Gateway, second succeeds
 			mockFetch.mockResolvedValueOnce(mockResponse("upstream request timeout", 504));
 			mockFetch.mockImplementationOnce(async (_url, init) =>
@@ -907,6 +922,7 @@ describe("Sandbox", () => {
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
 			// refresh: Running
 			mockFetch.mockResolvedValueOnce(mockResponse({ name: "sb-1", status: "Running" }));
+			mockFetch.mockResolvedValueOnce(pingResponse());
 			// First probe call fails with a network error.
 			mockFetch.mockRejectedValueOnce(new Error("network unreachable"));
 


### PR DESCRIPTION
TS parity with prokube/prokube-sdk#53 (pk-sandbox#107 phases 1 + 4). Backward compatible with pre-#107 backends.

## waitUntilReady
Long-poll rounds: `GET ?wait_phase=Running&timeout=≤20` with request timeout ≥ server hold + 5s margin, clamped to the caller's remaining budget; wait params dropped entirely under 1s of hold budget (plain GET). Rounds answered in <500ms without the target phase get a 1s pacing sleep — **old backends degrade to the old cadence**. Preserved: terminal states → `SandboxError`; deadline → `SandboxTimeoutError`; `RequestTimeoutError` swallowed+retried. `POLL_INTERVAL_MS` untouched for `waitForPause`/`waitUntilGone`.

## warmupKernel
One blocking `GET {name}/ping?wait=kernel&timeout=≤100` (pk-sandbox#108 agent endpoint via the #114 platform proxy), then marker verification **delegates to the existing probe loop** with the same absolute deadline (converges in one round normally — deliberately not a single-shot, mirroring the round-2 review finding on the Python PR). Error dispatch through the typed error layer: `RequestTimeoutError`/`NotFoundError`/400/405 → legacy probe loop; 503/504 → ping retried in-deadline with paced instant answers; other errors rethrow; <1s remaining → warn-and-return.

Version 0.2.0 → 0.3.0 (package.json, compat SDK_VERSION, README tags).

## Verification
- `biome check` clean, `tsc --noEmit` clean
- `npm run test`: **15 files, 284 tests passed** (baseline 274)
- New: 4 long-poll tests + 6 warmup-ping tests (incl. 400/404/405 `it.each`); budget clamps asserted via `captureRequestTimeouts`; ping mock added to all 8 existing warmup-reaching chains.